### PR TITLE
feat: Add Jellyfin & JellyStat

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 
 # Server Portal
 
-**A premium, fully-automated management and analytics portal for Plex Media Servers.**
+**A premium, fully-automated management and analytics portal for Plex and Jellyfin media servers.**
 
 Built with Node.js · Express · React · Tailwind CSS
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/Node.js-20%2B-green.svg)](https://nodejs.org/)
 [![Plex](https://img.shields.io/badge/Plex-Media%20Server-orange.svg)](https://www.plex.tv/)
+[![Jellyfin](https://img.shields.io/badge/Jellyfin-Media%20Server-00A4DC.svg)](https://jellyfin.org/)
 [![Docker Image Size](https://ghcr-badge.egpl.dev/jl94x4/server-manager-portal/size?label=docker%20image%20size&color=blue)](https://github.com/jl94x4/Server-Manager-Portal/pkgs/container/server-manager-portal)
 [![GitHub Stars](https://img.shields.io/github/stars/jl94x4/Server-Manager-Portal.svg?style=flat&logo=github&color=gold)](https://github.com/jl94x4/Server-Manager-Portal/stargazers)
 [![GitHub Forks](https://img.shields.io/github/forks/jl94x4/Server-Manager-Portal.svg?style=flat&logo=github)](https://github.com/jl94x4/Server-Manager-Portal/network/members)
@@ -20,9 +21,9 @@ Built with Node.js · Express · React · Tailwind CSS
 
 ---
 
-Server Portal is a self-hosted web application that turns your Plex Media Server into a fully managed streaming service. It handles everything from user onboarding and automated access management, to real-time analytics, live session monitoring, trending content discovery, and beautiful personalized wrap-ups for every user, all from one polished, mobile-first dashboard with a premium glass UI.
+Server Portal is a self-hosted web application that turns your Plex or Jellyfin server into a fully managed streaming service. It handles everything from user onboarding and automated access management, to real-time analytics, live session monitoring, trending content discovery, and personalized wrap-ups for every user, all from one polished, mobile-first dashboard with a premium glass UI.
 
-Once setup your users will be able to login using their own Plex account to see their own stats! 
+Once set up, users can sign in with Plex OAuth or Jellyfin authentication/Quick Connect to see their own portal, activity, and stats.
 
 ---
 <img width="2294" height="1218" alt="image" src="https://github.com/user-attachments/assets/16d548fb-c07c-4967-bd39-12ffdfac45c0" />
@@ -44,12 +45,12 @@ Every user gets a rich, personalized dashboard packed with insights about their 
 | **Media Profile** | Your viewer personality type (Movie Buff, TV Show Binger, Music Lover, Mixed Bag) with colour-coded breakdown bars, percentage splits, and top 3 movies + top 3 shows |
 | **Watch Style** | Discovery vs Rewatch analysis with a split progress bar and your top 5 most-rewatched titles |
 | **Streaming Habit** | Weekday vs Weekend split bar chart, average plays per day, and habit label (Weekend Warrior, Weekday Streamer, Balanced) |
-| **Top Library** | Your most-used Plex library with a full ranked breakdown of all libraries |
+| **Top Library** | Your most-used media library with a full ranked breakdown of all libraries |
 | **Top Day** | An animated bar chart showing your plays across all 7 days of the week, highlighting your peak day |
 | **Peak Hours** | An animated hourly distribution chart showing what time of day you stream the most |
 | **Time of Day** | Your streaming persona (Night Owl, Early Bird, Evening Streamer, Afternoon Watcher) with a contextual description |
 
-All cards open into detailed modals loaded with contextual data, Plex artwork, and dynamic charts.
+All cards open into detailed modals loaded with contextual data, media artwork, and dynamic charts.
 
 **Shareable wrap-up** - Export your personal wrap-up as a PNG image from the home dashboard. The share modal previews the real card grid and supports native share on supported devices, with download as a fallback.
 
@@ -62,7 +63,7 @@ All cards open into detailed modals loaded with contextual data, Plex artwork, a
 A comprehensive control panel for the server owner:
 
 - **Live Session Monitor** - Real-time view of all active streams with user avatar, media title, progress bar, stream type badge (Direct Play / Transcode), and a click-through technical modal showing video codec, audio codec, bitrate, channels, resolution, and transcode reason
-- **User Management Table** - View all users with their Plex avatar, username, email, access expiry date, last seen timestamp, and quick-action buttons (+1 Month, +1 Year, Unlimited, Revoke)
+- **User Management Table** - View all users with their Plex or Jellyfin avatar, username, email, access expiry date, last seen timestamp, and quick-action buttons (+1 Month, +1 Year, Unlimited, Revoke)
 - **Server Leaderboard** - Server-wide play count rankings across all time periods, updated automatically in the background
 - **Audit Log** - Timestamped record of all system actions (access granted, revoked, extended, expired)
 - **Settings UI** - Configure every aspect of the portal from the browser without touching config files
@@ -88,7 +89,7 @@ Layout settings are saved server-wide, validated on the backend, and applied to 
 
 ### Discover Page
 
-A curated content discovery experience for all users, powered by server-wide watch history and live Plex activity:
+A curated content discovery experience for all users, powered by server-wide watch history and live media activity:
 
 **Live activity**
 - Real-time stream summary cards (total streams, direct play, transcoding, bandwidth)
@@ -111,7 +112,7 @@ A curated content discovery experience for all users, powered by server-wide wat
 - **Cult Classics** - Niche content with extremely high plays relative to its tiny viewer count
 - **Blast from the Past** - Pre-2000 titles getting recent love
 
-All discover items display Plex artwork, play counts, and quality badges (4K, HDR, AV1/HEVC, Atmos, and more). Trending and analytics caches are reused on startup when still fresh, so the portal loads quickly after restarts.
+All discover items display server artwork, play counts, and quality badges (4K, HDR, AV1/HEVC, Atmos, and more). Trending and analytics caches are reused on startup when still fresh, so the portal loads quickly after restarts.
 
 ---
 
@@ -124,16 +125,17 @@ Browse your Sonarr and Radarr activity directly inside the portal:
 - **Recent History** - Import and grab history across both services
 - **Month Navigation** - Browse releases by month with auto-advance to the next month that has content
 
-Configure Sonarr/Radarr URLs and API keys in **Settings → Integrations**.
+Configure Sonarr/Radarr URLs and API keys in **Settings → Media Stack**.
 
 ---
 
 ### User Onboarding & Access Management
 
-- **Invite Link System** - Generate shareable invite links with a configurable max-use limit and custom duration. Users claim access via a branded landing page that automatically adds them to your Plex server
-- **Plex OAuth** - Secure login via official Plex.tv authentication. No passwords stored
+- **Invite Link System** - Generate shareable invite links with a configurable max-use limit and custom duration. Users claim access via a branded landing page
+- **Plex OAuth** - Secure login via official Plex.tv authentication. No Plex passwords stored
+- **Jellyfin Auth + Quick Connect** - Jellyfin portals support username/password auth and one-click Quick Connect, with admin detection from Jellyfin policy
 - **Automated Temporary Access** - Auto-grant configurable temporary access periods (e.g., 3 days) to all new users
-- **Access Expiry** - Set hard expiry dates per user. The system automatically removes Plex server access when time is up
+- **Access Expiry** - Set hard expiry dates per user. The system automatically revokes portal access when time is up
 - **Inactivity Cleanup** - Automatically remove users who haven't streamed in a configurable number of days, with per-user exemptions available
 - **Grace Period Notifications** - Warn users via email before their access expires
 
@@ -155,8 +157,8 @@ Beautiful, responsive HTML emails sent automatically:
 
 ### Public-Facing Pages
 
-- **Landing Page** - A sleek login page showing live library stats (total movies, shows, music) to entice new users
-- **Status Page** - A public `/status` dashboard showing the live uptime of your Plex server, request tools (Overseerr/Ombi), and download clients
+- **Landing Page** - A sleek login page showing live library stats (total movies, shows, music) and your configured server branding
+- **Status Page** - A public `/status` dashboard showing the live uptime of your media server, request tools (Seerr/Jellyseerr/Ombi), analytics companion, and download clients
 - **Invite Claim Page** - A dedicated, shareable page for invited users to claim their account
 
 ---
@@ -177,7 +179,7 @@ Beautiful, responsive HTML emails sent automatically:
 | **Backend** | Node.js, Express.js |
 | **Frontend** | React 18 (bundled via esbuild), TypeScript |
 | **Styling** | Tailwind CSS v3 |
-| **Auth** | JWT (httpOnly cookies) + Plex.tv OAuth |
+| **Auth** | JWT (httpOnly cookies) + Plex.tv OAuth or Jellyfin authentication |
 | **Data** | Local JSON flat-files (no database required) |
 | **Email** | Nodemailer (compatible with any SMTP provider) |
 | **Icons** | Lucide React |
@@ -187,12 +189,12 @@ Beautiful, responsive HTML emails sent automatically:
 
 ## Security
 
-- **No Passwords** - Authentication is handled 100% by Plex.tv. The app only stores Plex Account IDs, usernames, and emails
-- **JWT Session Security** - Cookies use `httpOnly`, `secure`, and `sameSite: lax` flags to reduce XSS and CSRF risk while keeping Plex OAuth redirects reliable
+- **No Plex Passwords** - Plex authentication is handled by Plex.tv OAuth. Jellyfin password login is exchanged directly with your Jellyfin server and is not stored by the portal
+- **JWT Session Security** - Cookies use `httpOnly`, `secure`, and `sameSite: lax` flags to reduce XSS and CSRF risk while keeping auth redirects reliable
 - **Rate Limiting** - Authentication endpoints have strict rate limiting to prevent brute-force attacks
 - **HTTP Security Headers** - HSTS, X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Referrer-Policy, and Permissions-Policy enforced on every response
-- **Admin Protection** - All admin routes are verified against live Plex server ownership, not just a stored flag. Home layout changes are admin-only and validated server-side
-- **Reverse Proxy Ready** - Supports Nginx, Caddy, and Cloudflare via `X-Forwarded-Proto` / `X-Forwarded-For` header trust, including optional subpath hosting (e.g. `https://plex.example.com/portal`)
+- **Admin Protection** - Admin routes require an authenticated admin session. Plex admins are verified from server ownership; Jellyfin admins are verified from Jellyfin user policy
+- **Reverse Proxy Ready** - Supports Nginx, Caddy, and Cloudflare via `X-Forwarded-Proto` / `X-Forwarded-For` header trust, including optional subpath hosting (e.g. `https://media.example.com/portal`)
 - **Injection Proof** - Uses a flat-file JSON system, making SQL injection structurally impossible
 
 ---
@@ -202,7 +204,7 @@ Beautiful, responsive HTML emails sent automatically:
 ### Prerequisites
 
 - **Node.js** v20.6 or newer (for native `.env` support)
-- A **Plex Media Server** with an admin Plex Token
+- A **Plex Media Server** with an admin Plex token, or a **Jellyfin Server** with an admin API key
 - *(Optional)* An SMTP provider for email notifications
 
 ### Installation
@@ -220,7 +222,7 @@ npm install
 
 **3. Generate your JWT secret**
 ```bash
-echo "JWT_SECRET=$(node -e "console.log(require('crypto').randomBytes(48).toString('hex'))")" > .env
+printf 'JWT_SECRET=%s\n' "$(node -e "console.log(require('crypto').randomBytes(48).toString('hex'))")" > .env
 ```
 
 **4. Start the application**
@@ -233,9 +235,19 @@ npm start
 **5. First-time admin setup**
 
 - Navigate to `http://localhost:2121`
-- Log in with your **Plex Admin account**
-- The app will auto-detect you as the server owner and grant Admin access
-- Go to **Settings** in the sidebar to configure your Plex token, SMTP, temporary access settings, and scheduled tasks
+- Choose **Plex** or **Jellyfin** in the first-time setup wizard
+- Plex setup uses Plex OAuth/token and server selection
+- Jellyfin setup uses Jellyfin URL + API key, then supports Jellyfin login and Quick Connect
+- Go to **Settings** in the sidebar to configure **Media Player**, SMTP, temporary access settings, branding, and scheduled tasks
+
+### Media player modes
+
+| Mode | Authentication | Analytics companion | Branding |
+|---|---|---|---|
+| **Plex** | Plex.tv OAuth, Plex token, selected owned server | Tautulli | Plex or custom theme |
+| **Jellyfin** | Jellyfin username/password or Quick Connect | Jellystat | Jellyfin server icon and splash screen proxy, or custom theme |
+
+Plex mode keeps the original Plex OAuth and Tautulli flow. Jellyfin mode uses your Jellyfin URL/API key for user sync, session activity, Quick Connect, and server branding assets.
 
 ---
 
@@ -292,7 +304,7 @@ PUBLIC_BASE_URL=https://portal.example.com
 docker compose up -d --build
 ```
 
-The portal listens on port **2121** by default. Open `http://localhost:2121` and sign in with your Plex admin account.
+The portal listens on port **2121** by default. Open `http://localhost:2121` and complete the first-time setup for Plex or Jellyfin.
 
 **3. Persisted data**
 
@@ -306,7 +318,7 @@ On first startup, any legacy JSON files still in the project root are automatica
 ### Docker Compose tips
 
 - Change the published port: set `PORT=8080` in `.env` (maps host `8080` → container `2121`).
-- Integrations on your LAN (Sonarr, Radarr, Tautulli): set `ALLOW_PRIVATE_INTEGRATION_URLS=true` and use reachable URLs from inside the container (e.g. `http://host.docker.internal:8989` on Docker Desktop, or your host IP on Linux).
+- Integrations on your LAN (Sonarr, Radarr, Tautulli, Jellystat, Seerr/Jellyseerr/Ombi): set `ALLOW_PRIVATE_INTEGRATION_URLS=true` and use reachable URLs from inside the container (e.g. `http://host.docker.internal:8989` on Docker Desktop, or your host IP on Linux).
 - View logs: `docker compose logs -f portal`
 - Update: `git pull && docker compose up -d --build`
 
@@ -343,12 +355,12 @@ Set `FORCE_SECURE_COOKIES=true` and `PUBLIC_BASE_URL=https://portal.example.com`
 
 #### Subpath hosting
 
-You can also host the portal under a path on an existing domain, for example `https://plex.example.com/portal` alongside Plex or other services.
+You can also host the portal under a path on an existing domain, for example `https://media.example.com/portal` alongside Plex, Jellyfin, or other services.
 
 Example Caddy:
 
 ```caddy
-plex.example.com {
+media.example.com {
     handle /portal/* {
         reverse_proxy localhost:2121
     }
@@ -359,7 +371,7 @@ Set these environment variables:
 
 ```env
 BASE_PATH=/portal
-PUBLIC_BASE_URL=https://plex.example.com/portal
+PUBLIC_BASE_URL=https://media.example.com/portal
 FORCE_SECURE_COOKIES=true
 ```
 
@@ -388,12 +400,12 @@ The template uses `ghcr.io/jl94x4/server-manager-portal:latest` by default.
 | `PORT` | No | Listen port inside the container (default `2121`) |
 | `BIND_HOST` | No | Bind address (default `0.0.0.0`) |
 | `CONFIG_DIR` | No | Runtime data directory (default `/app/config` in Docker) |
-| `PUBLIC_BASE_URL` | Recommended | Public HTTPS URL for links and emails. Include the subpath when using one, e.g. `https://plex.example.com/portal` |
+| `PUBLIC_BASE_URL` | Recommended | Public HTTPS URL for links and emails. Include the subpath when using one, e.g. `https://media.example.com/portal` |
 | `BASE_PATH` | No | URL prefix when hosted under a subpath (e.g. `/portal`). Leave empty for root hosting |
 | `FORCE_SECURE_COOKIES` | Recommended | Set `true` when behind HTTPS |
 | `ALLOW_PRIVATE_INTEGRATION_URLS` | No | Allow LAN/private URLs for Arr stack integrations |
 | `SETUP_TOKEN` | No | Token for remote first-time setup |
-| `CLIENT_ID` | No | Fixed Plex OAuth client id (auto-generated if unset) |
+| `CLIENT_ID` | No | Fixed Plex OAuth client id (auto-generated if unset; Plex mode only) |
 
 See `.env.example` for a full template.
 
@@ -405,16 +417,37 @@ All configuration is managed through the **Settings UI** in the browser. Key opt
 
 | Setting | Description |
 |---|---|
-| Plex Token | Your Plex admin token for API access |
-| Plex Server URL | Local or remote address of your Plex server |
-| Direct Plex URL | LAN URL for faster Plex image and history fetches (recommended in Docker) |
+| Media Player | Choose Plex or Jellyfin |
+| Plex Token / Server | Plex admin token, selected server, and optional direct Plex URL |
+| Jellyfin URL / API Key | Jellyfin server URL and API key for users, sessions, Quick Connect, and branding proxy |
+| Branding & UI | Portal accent colour, server logo, Jellyfin/Plex preset, and splash background |
 | Temporary Access Duration | Number of days new users get for free |
 | Inactivity Threshold | Days of inactivity before auto-removal |
 | SMTP Settings | Host, port, username, password, from address |
 | Newsletter Schedule | Weekly or monthly, with day/time selection |
 | Home Layout | Section order and visibility for the user home page |
-| Sonarr / Radarr URLs | For embedding media request tools |
+| Sonarr / Radarr URLs | For media stack calendar, queue, and history |
+| Tautulli / Jellystat | Tautulli for Plex analytics, Jellystat for Jellyfin analytics |
 | Status Page Services | Define services and their health check URLs |
+
+---
+
+## Background Tasks
+
+The **Settings → Background Tasks** page shows the active scheduler and lets admins run jobs manually. Task labels follow the selected media player:
+
+| Task | Plex mode | Jellyfin mode |
+|---|---|---|
+| User sync | Sync Plex Users | Sync Jellyfin Users |
+| Expiry checks | Email users nearing expiry | Same |
+| Revoke access | Removes expired Plex access | Revokes expired portal access |
+| Inactive cleanup | Revokes inactive users | Revokes inactive Jellyfin portal users |
+| Analytics cache | Uses Plex/Tautulli data where configured | Uses Jellyfin/Jellystat data where configured |
+| Library stats | Plex Stats Builder | Hidden in Jellyfin mode |
+| Maintenance index | Builds media/request index for cleanup rules | Same |
+| Auto rolling backup | Creates rolling config backups | Same |
+
+The **Settings → System** diagnostics page uses the same media-aware task list so Jellyfin portals are not penalized for Plex-only jobs.
 
 ---
 
@@ -422,13 +455,13 @@ All configuration is managed through the **Settings UI** in the browser. Key opt
 
 ```
 Server-Manager-Portal/
-├── index.js            # Backend: Express API, Plex integration, auth, email, scheduling
+├── index.js            # Backend: Express API, Plex/Jellyfin integrations, auth, email, background jobs
 ├── index.tsx           # Frontend entry point
 ├── client/             # React application source
 │   ├── App.tsx         # App shell, routing, responsive layout
 │   ├── screens.tsx     # Dashboards, Discover, login, and shared screens
 │   ├── home/           # User dashboard layout and widget renderers
-│   ├── settings/       # Settings UI (including Home Layout editor)
+│   ├── settings/       # Settings UI (Media Player, Home Layout, System, Background Tasks)
 │   ├── shared/         # API helpers, types, theme, skeletons, wrap-up cards
 │   ├── setup/          # First-time setup wizard
 │   └── maintenance/    # Library maintenance panel

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { SettingsDashboard } from './settings/SettingsDashboard';
 import { bindAppConfirm } from './shared/confirm';
 import { apiFetch } from './shared/api';
-import { getPublicOrigin, portalUrl, stripBasePath } from './shared/basePath';
-import { hexToRgb } from './shared/format';
+import { getPublicOrigin, portalUrl, resolvePortalAssetUrl, stripBasePath } from './shared/basePath';
+import { accentHoverRgb, hexToRgb } from './shared/format';
 import { ConfirmModal } from './shared/ui';
 import { Loader } from './shared/toast';
 import { AppAmbientBackground } from './shared/theme';
@@ -70,6 +70,7 @@ export const MainApp: React.FC = () => {
             setPublicConfig(data);
             if (data.primaryColor) {
                 document.documentElement.style.setProperty('--color-plex', hexToRgb(data.primaryColor));
+                document.documentElement.style.setProperty('--color-plex-hover', accentHoverRgb(data.primaryColor));
             }
             if (data.customLogoUrl) {
                 updateFavicon(data.customLogoUrl);
@@ -195,7 +196,7 @@ export const MainApp: React.FC = () => {
             return <PublicInviteClaim code={code} />;
         }
         if (currentRoute === 'status') return <StatusDashboard onBack={() => isPublicStatus ? setRoute('login') : setRoute('user')} isAdmin={isAdmin} isPublic={isPublicStatus} />;
-        if (currentRoute === 'dashboard') return <LibraryDashboard onBack={() => setRoute('user')} isAdmin={isAdmin} publicConfig={publicConfig} />;
+        if (currentRoute === 'dashboard') return <LibraryDashboard onBack={() => setRoute('user')} isAdmin={isAdmin} publicConfig={publicConfig} mediaServerType={sessionInfo?.mediaServerType} />;
         if (currentRoute === 'settings' && isAdmin) return <SettingsDashboard />;
         if (currentRoute === 'maintenance' && isAdmin) return <MaintenanceDashboard />;
         if (currentRoute === 'logs' && isAdmin) return <LogsDashboard onLogout={handleLogout} />;
@@ -209,7 +210,7 @@ export const MainApp: React.FC = () => {
         <div className="relative flex w-full min-h-screen overflow-x-clip">
             <AppAmbientBackground />
             <ConfirmModal isOpen={confirmState.isOpen} message={confirmState.message} onConfirm={handleConfirm} onCancel={closeConfirm} />
-            {!isPublicView && <Navigation currentRoute={currentRoute} onNavigate={setRoute as any} onLogout={handleLogout} isAdmin={isAdmin} serverName={sessionInfo?.serverName || 'Server Portal'} adminThumb={sessionInfo?.adminThumb} requestUrl={sessionInfo?.requestUrl || 'https://yourdomain.com'} navOrder={sessionInfo?.navOrder || ['home', 'discover', 'status', 'analytics', 'mediastack', 'maintenance', 'request', 'settings', 'logout']} appVersion={publicConfig.appVersion} />}
+            {!isPublicView && <Navigation currentRoute={currentRoute} onNavigate={setRoute as any} onLogout={handleLogout} isAdmin={isAdmin} serverName={sessionInfo?.serverName || 'Server Portal'} adminThumb={sessionInfo?.adminThumb} customLogoUrl={publicConfig?.customLogoUrl} requestUrl={sessionInfo?.requestUrl || 'https://yourdomain.com'} navOrder={sessionInfo?.navOrder || ['home', 'discover', 'status', 'analytics', 'mediastack', 'maintenance', 'request', 'settings', 'logout']} appVersion={publicConfig.appVersion} />}
             <div className={`relative z-10 flex-1 min-w-0 flex flex-col items-center px-4 pt-20 pb-[80px] md:p-8 md:pt-8 md:pb-8 overflow-x-visible ${isPublicView ? '!pt-8 !pb-8' : ''}`}>
                 <div className="w-full min-w-0" style={{ maxWidth: contentMaxWidth }}>
                     {renderView()}

--- a/client/home/userDashboardWidgetRenderers.tsx
+++ b/client/home/userDashboardWidgetRenderers.tsx
@@ -5,6 +5,7 @@ import {
     ChevronLeft,
     ChevronRight,
     Film,
+    Layers,
     Music,
     Settings,
     Shield,
@@ -98,6 +99,7 @@ export const createMainGridWidgetRenderer = (deps: UserDashboardWidgetDeps) => {
         { value: 180, label: 'Last 180 Days' },
         { value: 'all' as const, label: 'All Time' },
     ];
+    const isJellyfinPortal = String(publicConfig?.mediaServerType || 'plex').toLowerCase() === 'jellyfin';
 
     return (id: MainGridWidgetId): React.ReactNode => {
         switch (id) {
@@ -261,6 +263,38 @@ export const createMainGridWidgetRenderer = (deps: UserDashboardWidgetDeps) => {
                     </div>
                 );
             case 'libraryStats':
+                if (isJellyfinPortal) {
+                    return (
+                        <div className="glass-card p-4 md:p-5 shadow-xl flex flex-col justify-center flex-shrink-0">
+                            <div className="flex items-center justify-between mb-3 md:mb-4">
+                                <p className="text-muted text-sm uppercase tracking-widest font-semibold">Jellyfin Library</p>
+                            </div>
+                            {serverDataLoading && !serverStats ? (
+                                <LibraryStatsSkeleton />
+                            ) : serverStats ? (
+                                <div className="grid grid-cols-1 sm:grid-cols-3 gap-2.5 md:gap-3">
+                                    <div className="bg-background/60 p-3 md:p-4 rounded-2xl border border-white/5 flex flex-col items-center justify-center text-center shadow-inner hover:bg-background/80 transition-colors">
+                                        <Film className="w-7 h-7 text-plex mb-2 opacity-80" />
+                                        <span className="text-3xl font-black text-text drop-shadow-md mb-1">{serverStats.movies?.toLocaleString?.() || 0}</span>
+                                        <span className="text-[10px] sm:text-xs font-bold uppercase tracking-wider text-muted">Movies</span>
+                                    </div>
+                                    <div className="bg-background/60 p-3 md:p-4 rounded-2xl border border-white/5 flex flex-col items-center justify-center text-center shadow-inner hover:bg-background/80 transition-colors">
+                                        <Tv className="w-7 h-7 text-plex mb-2 opacity-80" />
+                                        <span className="text-3xl font-black text-text drop-shadow-md mb-1">{serverStats.shows?.toLocaleString?.() || 0}</span>
+                                        <span className="text-[10px] sm:text-xs font-bold uppercase tracking-wider text-muted">{serverStats.episodes?.toLocaleString?.() || 0} Episodes</span>
+                                    </div>
+                                    <div className="bg-background/60 p-3 md:p-4 rounded-2xl border border-white/5 flex flex-col items-center justify-center text-center shadow-inner hover:bg-background/80 transition-colors">
+                                        <Layers className="w-7 h-7 text-plex mb-2 opacity-80" />
+                                        <span className="text-3xl font-black text-text drop-shadow-md mb-1">{formatBytes(serverStats.totalCatalogBytes || 0)}</span>
+                                        <span className="text-[10px] sm:text-xs font-bold uppercase tracking-wider text-muted">Catalog Size</span>
+                                    </div>
+                                </div>
+                            ) : (
+                                <div className="text-muted text-sm bg-background/50 p-4 rounded-xl border border-white/5">Could not load Jellyfin library statistics at this time.</div>
+                            )}
+                        </div>
+                    );
+                }
                 return (
                     <div className="glass-card p-4 md:p-5 shadow-xl flex flex-col justify-center flex-shrink-0">
                         <div className="flex items-center justify-between mb-3 md:mb-4">
@@ -308,6 +342,56 @@ export const createMainGridWidgetRenderer = (deps: UserDashboardWidgetDeps) => {
                 );
             case 'analytics':
                 if (!sessionInfo.session.isAdmin && !user) return null;
+                if (isJellyfinPortal) {
+                    return (
+                        <div className="glass-card p-3 md:p-4 shadow-xl flex flex-col flex-1 min-h-0">
+                            <div className="flex items-center justify-between flex-shrink-0">
+                                <h2 className="text-lg md:text-xl font-bold text-text flex items-center gap-2">
+                                    <Activity className="w-5 h-5 text-plex" /> Jellystat Activity
+                                </h2>
+                                <PeriodDropdown
+                                    value={analyticsDays}
+                                    open={analyticsDaysOpen}
+                                    onToggle={() => setAnalyticsDaysOpen(!analyticsDaysOpen)}
+                                    onClose={() => setAnalyticsDaysOpen(false)}
+                                    onChange={(value) => setAnalyticsDays(value as number | 'all')}
+                                    options={analyticsDaysOptions}
+                                />
+                            </div>
+                            {analyticsLoading ? (
+                                <div className="flex items-center gap-3 text-muted mt-4">
+                                    <div className="w-5 h-5 rounded-full border-2 border-plex border-t-transparent animate-spin" />
+                                    Loading Jellystat activity...
+                                </div>
+                            ) : analytics && analytics.totalPlays > 0 ? (
+                                <div className="grid grid-cols-2 lg:grid-cols-4 gap-2.5 mt-4">
+                                    <div className="bg-background/60 rounded-xl border border-white/5 p-3">
+                                        <p className="text-[10px] text-muted uppercase tracking-widest font-bold">Total Plays</p>
+                                        <p className="text-2xl font-black text-text mt-1">{analytics.totalPlays?.toLocaleString?.() || 0}</p>
+                                    </div>
+                                    <div className="bg-background/60 rounded-xl border border-white/5 p-3">
+                                        <p className="text-[10px] text-muted uppercase tracking-widest font-bold">Top Library</p>
+                                        <p className="text-sm font-bold text-text mt-1 truncate">{analytics.favoriteLibrary || 'None'}</p>
+                                    </div>
+                                    <div className="bg-background/60 rounded-xl border border-white/5 p-3">
+                                        <p className="text-[10px] text-muted uppercase tracking-widest font-bold">Top Movie</p>
+                                        <p className="text-sm font-bold text-text mt-1 truncate">{analytics.topMovie?.title || 'None'}</p>
+                                    </div>
+                                    <div className="bg-background/60 rounded-xl border border-white/5 p-3">
+                                        <p className="text-[10px] text-muted uppercase tracking-widest font-bold">Top Show</p>
+                                        <p className="text-sm font-bold text-text mt-1 truncate">{analytics.topBinge?.title || 'None'}</p>
+                                    </div>
+                                </div>
+                            ) : (
+                                <div className="flex flex-col items-center justify-center p-4 md:p-5 text-center flex-1 min-h-0 mt-2 md:mt-3">
+                                    <div className="w-12 h-12 rounded-full bg-white/5 flex items-center justify-center mb-3 text-xl shadow-inner">🍿</div>
+                                    <h3 className="font-bold text-text mb-1">No Jellystat activity yet</h3>
+                                    <p className="text-muted text-sm max-w-sm">Once Jellystat records playback activity, your server activity summary will appear right here.</p>
+                                </div>
+                            )}
+                        </div>
+                    );
+                }
                 return (
                     <div className="glass-card p-3 md:p-4 shadow-xl flex flex-col flex-1 min-h-0">
                         <div className="flex items-center justify-between flex-shrink-0">

--- a/client/screens.tsx
+++ b/client/screens.tsx
@@ -29,6 +29,29 @@ import { activityStreamColumnCount, activityStreamGridClass, discoverPosterGridC
 import { UserDashboardLayout } from './home/UserDashboardLayout';
 import { createMainGridWidgetRenderer, createRecentlyAddedWidgetRenderer } from './home/userDashboardWidgetRenderers';
 
+const JELLYFIN_ICON_URL = 'https://cdn.jsdelivr.net/gh/selfhst/icons/svg/jellyfin.svg';
+
+const jellyfinQuickConnectUrl = (baseUrl: string) => {
+    const base = String(baseUrl || '').replace(/\/+$/, '');
+    return base ? `${base}/web/#/quickconnect` : '';
+};
+
+const copyTextToClipboard = async (value: string) => {
+    if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(value);
+        return;
+    }
+    const textarea = document.createElement('textarea');
+    textarea.value = value;
+    textarea.setAttribute('readonly', 'true');
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+};
+
 declare global {
     interface Window {
         __USE_24_HOUR_CLOCK__?: boolean;
@@ -73,7 +96,8 @@ const UserCard: React.FC<{
     isConfigured: boolean;
     isSelected: boolean;
     onSelect: (id: string) => void;
-}> = ({ user, onEdit, onDelete, onRevoke, isConfigured, isSelected, onSelect }) => {
+    providerLabel?: string;
+}> = ({ user, onEdit, onDelete, onRevoke, isConfigured, isSelected, onSelect, providerLabel = 'Plex' }) => {
     const { status, statusText, daysRemainingText, pillClass, borderClass } = useMemo(() => {
         const days = getDaysUntilExpiry(user.expiryDate);
         let status: UserStatus = 'active';
@@ -120,7 +144,7 @@ const UserCard: React.FC<{
                         style={{ borderRadius: '50%' }}
                     />
                     {user.thumb ? (
-                        <img src={user.thumb} alt={user.username} className="w-10 h-10 rounded-full object-cover border border-border flex-shrink-0" />
+                        <img src={resolvePortalAssetUrl(user.thumb)} alt={user.username} className="w-10 h-10 rounded-full object-cover border border-border flex-shrink-0" />
                     ) : (
                         <div className="w-10 h-10 rounded-full bg-border flex items-center justify-center text-text font-bold text-sm uppercase flex-shrink-0">
                             {user.username.substring(0, 2)}
@@ -143,7 +167,7 @@ const UserCard: React.FC<{
                     <span className="text-text font-medium flex flex-wrap justify-end md:items-center gap-1"><span className="whitespace-nowrap">{formatDate(user.expiryDate)}</span> <span className="text-[0.7rem] text-muted whitespace-nowrap">({daysRemainingText})</span></span>
                 </div>
                 <div className="flex justify-between items-center text-sm pb-2 border-b border-white/5 last:border-0 last:pb-0">
-                    <span className="text-muted text-xs uppercase tracking-wider font-bold">Plex</span>
+                    <span className="text-muted text-xs uppercase tracking-wider font-bold">{providerLabel}</span>
                     <span className="info-value plex-status">
                         <span className={`plex-status-dot ${user.plexAccessStatus || 'unknown'}`}></span>
                         {(user.plexAccessStatus || 'unknown').charAt(0).toUpperCase() + (user.plexAccessStatus || 'unknown').slice(1)}
@@ -1835,6 +1859,16 @@ export const AnalyticsDashboard: React.FC<{ isAdmin: boolean, sessionInfo: any }
     const [viewerPage, setViewerPage] = useState(1);
     const viewersPerPage = 10;
     const [viewTab, setViewTab] = useState<'overview' | 'graphs'>('overview');
+    const mediaServerType = String(sessionInfo?.mediaServerType || 'plex').toLowerCase();
+    const isJellyfinPortal = mediaServerType === 'jellyfin';
+    const analyticsSourceLabel = isJellyfinPortal ? 'Jellystat' : 'Tautulli';
+    const resolveUserAvatar = (thumb: string | null | undefined, width = 80, height = 80) => {
+        if (!thumb) return logoUrl();
+        if (thumb.startsWith('http://') || thumb.startsWith('https://') || thumb.startsWith('/api/')) {
+            return resolvePortalAssetUrl(thumb);
+        }
+        return portalUrl(`/api/plex/image?path=${encodeURIComponent(thumb)}&width=${width}&height=${height}`);
+    };
 
     useEffect(() => {
         if (!isAdmin) return;
@@ -1853,18 +1887,19 @@ export const AnalyticsDashboard: React.FC<{ isAdmin: boolean, sessionInfo: any }
         let cancelled = false;
         const fetchAnalytics = async () => {
             setLoading(true);
+            setError(null);
             try {
-                const data = await apiFetch(`/api/plex/analytics?days=${days}`);
+                const data = await apiFetch(`${isJellyfinPortal ? '/api/jellystat/analytics' : '/api/plex/analytics'}?days=${days}`);
                 if (cancelled) return;
                 setAnalyticsData(data);
 
                 if (isAdmin) {
                     try {
-                        const tData = await apiFetch('/api/tautulli/stats');
+                        const tData = isJellyfinPortal ? data.jellystatInsights : await apiFetch('/api/tautulli/stats');
                         if (cancelled) return;
                         setTautulliData(tData);
                     } catch (e) {
-                        // Tautulli might not be configured, ignore error
+                        // Tautulli/Jellystat might not be configured, ignore the extra panel.
                         if (!cancelled) setTautulliData(null);
                     }
                 } else {
@@ -1878,7 +1913,11 @@ export const AnalyticsDashboard: React.FC<{ isAdmin: boolean, sessionInfo: any }
         };
         fetchAnalytics();
         return () => { cancelled = true; };
-    }, [days, isAdmin]);
+    }, [days, isAdmin, isJellyfinPortal]);
+
+    useEffect(() => {
+        if (isJellyfinPortal && viewTab === 'graphs') setViewTab('overview');
+    }, [isJellyfinPortal, viewTab]);
 
     const topUsersLength = analyticsData?.topUsers?.length || 0;
     const totalViewerPages = Math.max(1, Math.ceil(topUsersLength / viewersPerPage));
@@ -1958,9 +1997,11 @@ export const AnalyticsDashboard: React.FC<{ isAdmin: boolean, sessionInfo: any }
                         <button onClick={() => setViewTab('overview')} className={`px-4 py-2 rounded-md text-sm font-bold uppercase tracking-wider transition-colors flex items-center gap-2 ${viewTab === 'overview' ? 'bg-plex text-white shadow-lg' : 'text-muted hover:text-white'}`}>
                             <Activity className="w-4 h-4" /> Overview
                         </button>
-                        <button onClick={() => setViewTab('graphs')} className={`px-4 py-2 rounded-md text-sm font-bold uppercase tracking-wider transition-colors flex items-center gap-2 ${viewTab === 'graphs' ? 'bg-plex text-white shadow-lg' : 'text-muted hover:text-white'}`}>
-                            <LucideLineChart className="w-4 h-4" /> Graphs
-                        </button>
+                        {!isJellyfinPortal && (
+                            <button onClick={() => setViewTab('graphs')} className={`px-4 py-2 rounded-md text-sm font-bold uppercase tracking-wider transition-colors flex items-center gap-2 ${viewTab === 'graphs' ? 'bg-plex text-white shadow-lg' : 'text-muted hover:text-white'}`}>
+                                <LucideLineChart className="w-4 h-4" /> Graphs
+                            </button>
+                        )}
                     </div>
                 </div>
                 {viewTab === 'overview' && (
@@ -2110,7 +2151,7 @@ export const AnalyticsDashboard: React.FC<{ isAdmin: boolean, sessionInfo: any }
                                                             }}
                                                         >
                                                             {u.thumb ? (
-                                                                <img src={u.thumb.startsWith('http') ? u.thumb : portalUrl(`/api/plex/image?path=${encodeURIComponent(u.thumb)}&width=32&height=32`)} className="w-8 h-8 rounded-full object-cover border border-border flex-shrink-0" />
+                                                                <img src={resolveUserAvatar(u.thumb, 32, 32)} className="w-8 h-8 rounded-full object-cover border border-border flex-shrink-0" />
                                                             ) : (
                                                                 <div className="w-8 h-8 rounded-full bg-border flex items-center justify-center text-[10px] font-bold border border-border/50 flex-shrink-0">{u.username.substring(0, 2).toUpperCase()}</div>
                                                             )}
@@ -2131,7 +2172,7 @@ export const AnalyticsDashboard: React.FC<{ isAdmin: boolean, sessionInfo: any }
                                         <div className="flex items-center gap-4">
                                             <div className="relative">
                                                 <div className="w-10 h-10 rounded-full p-[2px] bg-gradient-to-r from-plex to-[#e5a00d]">
-                                                    <img src={user.thumb ? (user.thumb.startsWith('http') ? user.thumb : portalUrl(`/api/plex/image?path=${encodeURIComponent(user.thumb)}&width=80&height=80`)) : logoUrl()} alt={user.username} className="w-full h-full rounded-full object-cover bg-card" onError={(e) => { (e.target as HTMLImageElement).src = logoUrl(); }} />
+                                                    <img src={resolveUserAvatar(user.thumb, 80, 80)} alt={user.username} className="w-full h-full rounded-full object-cover bg-card" onError={(e) => { (e.target as HTMLImageElement).src = logoUrl(); }} />
                                                 </div>
                                                 <div className="absolute -top-2 -right-2 bg-plex text-black font-bold text-[10px] w-5 h-5 rounded-full flex items-center justify-center">#{((viewerPageSafe - 1) * viewersPerPage) + idx + 1}</div>
                                             </div>
@@ -2207,13 +2248,13 @@ export const AnalyticsDashboard: React.FC<{ isAdmin: boolean, sessionInfo: any }
                             )}
                         </div>
 
-                        {/* Tautulli Insights Card */}
+                        {/* Media Analytics Insights Card */}
                         {tautulliData && (
                             <div className="glass-card-sm p-4 md:p-6 col-span-full relative overflow-hidden">
                                 <div className="absolute top-0 right-0 p-3 opacity-10 pointer-events-none">
                                     <Activity className="w-32 h-32 text-[#3b82f6]" />
                                 </div>
-                                <h2 className="text-xl font-bold text-text mb-6 uppercase tracking-wider flex items-center gap-2 relative z-10"><Activity className="text-[#3b82f6] w-5 h-5" /> Tautulli All-Time Insights</h2>
+                                <h2 className="text-xl font-bold text-text mb-6 uppercase tracking-wider flex items-center gap-2 relative z-10"><Activity className="text-[#3b82f6] w-5 h-5" /> {analyticsSourceLabel} Insights</h2>
                                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4 relative z-10">
                                     <div className="flex flex-col p-4 bg-black/20 rounded-lg border border-white/5 shadow-inner">
                                         <span className="font-bold text-muted text-xs uppercase tracking-wider mb-2 flex items-center gap-2"><Users className="w-4 h-4 text-[#3b82f6]" /> Peak Streams</span>
@@ -2557,6 +2598,8 @@ export const AdminDashboard: React.FC<{ onLogout: () => void, onViewUserPortal: 
     const [searchQuery, setSearchQuery] = useState('');
     const [statusFilter, setStatusFilter] = useState<'all' | 'active' | 'trial' | 'expiring' | 'expired' | 'revoked'>('all');
     const [sortBy, setSortBy] = useState<'username-asc' | 'username-desc' | 'expiry-asc' | 'expiry-desc' | 'joined-desc'>('username-asc');
+    const mediaServerType = String(configSettings.mediaServerType || 'plex').toLowerCase();
+    const mediaServerLabel = mediaServerType === 'jellyfin' ? 'Jellyfin' : 'Plex';
 
     const addToast = useCallback((message: string, type: 'success' | 'error' = 'success') => {
         setToasts(t => pushToast(t, message, type));
@@ -2596,7 +2639,7 @@ export const AdminDashboard: React.FC<{ onLogout: () => void, onViewUserPortal: 
                     await fetchUsers();
                     await fetchSecurityData();
                 } else {
-                    addToast('Welcome! Please configure your Plex settings to begin.', 'success');
+                    addToast('Welcome! Please configure your media server settings to begin.', 'success');
                     setSettingsModalOpen(true);
                 }
             } catch (error) {
@@ -2644,13 +2687,13 @@ export const AdminDashboard: React.FC<{ onLogout: () => void, onViewUserPortal: 
 
     const handleImportUsers = async () => {
         if (!isConfigured) {
-            addToast('Please configure Plex settings first.', 'error');
+            addToast(`Please configure ${mediaServerLabel} settings first.`, 'error');
             return;
         }
         setLoading(true);
         try {
             const result = await apiFetch('/api/sync', { method: 'POST' });
-            addToast(result.message || `Synced ${result.count} users from Plex.`);
+            addToast(result.message || `Synced ${result.count} users from ${mediaServerLabel}.`);
             await fetchUsers(); // Refresh user list
             await fetchSecurityData();
         } catch (error) {
@@ -2703,7 +2746,7 @@ export const AdminDashboard: React.FC<{ onLogout: () => void, onViewUserPortal: 
     };
 
     const handleDeleteUser = async (userId: string) => {
-        appConfirm('Are you sure you want to delete this user? This will revoke Plex access first.', async () => {
+        appConfirm(`Are you sure you want to delete this user? This will revoke ${mediaServerLabel} access first where supported.`, async () => {
             setLoading(true);
             try {
                 await apiFetch(`/api/users/${userId}`, { method: 'DELETE' });
@@ -2834,7 +2877,7 @@ export const AdminDashboard: React.FC<{ onLogout: () => void, onViewUserPortal: 
                         <span className="font-bold text-muted uppercase tracking-wider text-sm hidden md:inline-block mr-2">Quick Actions:</span>
                         <div className="grid grid-cols-2 md:flex md:flex-row gap-3 w-full md:w-auto flex-1">
                             <button className="col-span-2 md:col-span-1 px-3 py-2 bg-plex text-background rounded-md font-bold hover:bg-plex-hover transition-colors flex items-center justify-center gap-2 text-sm md:text-base" onClick={handleImportUsers} disabled={isLoading}>
-                                Sync Plex Users
+                                Sync {mediaServerLabel} Users
                             </button>
                         </div>
                     </div>
@@ -2940,6 +2983,7 @@ export const AdminDashboard: React.FC<{ onLogout: () => void, onViewUserPortal: 
                             isConfigured={isConfigured}
                             isSelected={selectedUserIds.includes(user.id)}
                             onSelect={handleToggleSelection}
+                            providerLabel={mediaServerLabel}
                         />
                     ))}
                 </div>
@@ -3096,7 +3140,12 @@ const LivePlexStats: React.FC = () => {
 export const Login: React.FC<{ onLoginSuccess: () => void, publicConfig?: any, initialError?: string }> = ({ onLoginSuccess, publicConfig, initialError }) => {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState(initialError || '');
-    const [publicInfo, setPublicInfo] = useState<{ thumb: string | null, serverName: string, isConfigured: boolean | null }>({ thumb: null, serverName: 'Server Portal', isConfigured: null });
+    const [jellyfinUsername, setJellyfinUsername] = useState('');
+    const [jellyfinPassword, setJellyfinPassword] = useState('');
+    const [showJellyfinPassword, setShowJellyfinPassword] = useState(false);
+    const [quickConnect, setQuickConnect] = useState<{ sessionId: string, code: string, jellyfinUrl: string } | null>(null);
+    const quickConnectPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const [publicInfo, setPublicInfo] = useState<{ thumb: string | null, serverName: string, isConfigured: boolean | null, mediaServerType?: string }>({ thumb: null, serverName: 'Server Portal', isConfigured: null, mediaServerType: 'plex' });
 
     const fetchPublicInfo = () => {
         apiFetch('/api/public/info').then(data => {
@@ -3104,7 +3153,8 @@ export const Login: React.FC<{ onLoginSuccess: () => void, publicConfig?: any, i
                 setPublicInfo({
                     thumb: data.thumb || null,
                     serverName: data.serverName || 'Server Portal',
-                    isConfigured: data.isConfigured !== false
+                    isConfigured: data.isConfigured !== false,
+                    mediaServerType: data.mediaServerType || 'plex'
                 });
                 if (data.thumb) updateFavicon(data.thumb);
                 if (data.serverName) document.title = `${data.serverName} Portal`;
@@ -3119,6 +3169,10 @@ export const Login: React.FC<{ onLoginSuccess: () => void, publicConfig?: any, i
             window.history.replaceState({}, '', portalUrl('/'));
         }
     }, [initialError]);
+
+    useEffect(() => () => {
+        if (quickConnectPollRef.current) clearInterval(quickConnectPollRef.current);
+    }, []);
 
     useEffect(() => {
         fetchPublicInfo();
@@ -3167,6 +3221,78 @@ export const Login: React.FC<{ onLoginSuccess: () => void, publicConfig?: any, i
         }
     };
 
+    const handleJellyfinLogin = async (event?: React.FormEvent) => {
+        event?.preventDefault();
+        setIsLoading(true);
+        setError('');
+        try {
+            await apiFetch('/api/auth/jellyfin/login', {
+                method: 'POST',
+                body: JSON.stringify({ username: jellyfinUsername.trim(), password: jellyfinPassword }),
+            });
+            onLoginSuccess();
+        } catch (e: any) {
+            setError(e.message || 'Failed to authenticate with Jellyfin');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const stopQuickConnectPolling = () => {
+        if (quickConnectPollRef.current) {
+            clearInterval(quickConnectPollRef.current);
+            quickConnectPollRef.current = null;
+        }
+    };
+
+    const pollJellyfinQuickConnect = (sessionId: string) => {
+        stopQuickConnectPolling();
+        quickConnectPollRef.current = setInterval(async () => {
+            try {
+                const data = await apiFetch('/api/auth/jellyfin/quick-connect/poll', {
+                    method: 'POST',
+                    body: JSON.stringify({ sessionId }),
+                });
+                if (data?.success) {
+                    stopQuickConnectPolling();
+                    onLoginSuccess();
+                }
+            } catch (e: any) {
+                stopQuickConnectPolling();
+                setIsLoading(false);
+                setError(e.message || 'Jellyfin Quick Connect failed');
+            }
+        }, 5000);
+    };
+
+    const handleJellyfinQuickConnect = async () => {
+        setIsLoading(true);
+        setError('');
+        try {
+            const data = await apiFetch('/api/auth/jellyfin/quick-connect/initiate', { method: 'POST' });
+            setQuickConnect({
+                sessionId: data.sessionId,
+                code: data.code,
+                jellyfinUrl: data.jellyfinUrl || '',
+            });
+            setIsLoading(false);
+            pollJellyfinQuickConnect(data.sessionId);
+        } catch (e: any) {
+            setIsLoading(false);
+            setError(e.message || 'Failed to start Jellyfin Quick Connect');
+        }
+    };
+
+    const handleOpenJellyfinQuickConnect = async () => {
+        if (!quickConnect?.jellyfinUrl) return;
+        try {
+            await copyTextToClipboard(quickConnect.code);
+        } catch {
+            // Clipboard access can be blocked by browser settings; opening Jellyfin is still useful.
+        }
+        window.open(jellyfinQuickConnectUrl(quickConnect.jellyfinUrl), '_blank', 'noopener,noreferrer');
+    };
+
     if (publicInfo.isConfigured === false || (typeof window !== 'undefined' && stripBasePath(window.location.pathname).startsWith('/auth/setup/'))) {
         return <SetupWizard onComplete={fetchPublicInfo} />;
     }
@@ -3175,14 +3301,17 @@ export const Login: React.FC<{ onLoginSuccess: () => void, publicConfig?: any, i
         return <Loader isLoading={true} />;
     }
 
-    const showTrialAccess = publicConfig?.allowTemporaryAccess !== false;
+    const mediaServerType = String(publicConfig?.mediaServerType || publicInfo.mediaServerType || 'plex').toLowerCase();
+    const isJellyfinAuth = mediaServerType === 'jellyfin';
+    const showTrialAccess = !isJellyfinAuth && publicConfig?.allowTemporaryAccess !== false;
     const logoSrc = publicConfig?.customLogoUrl
         ? resolvePortalAssetUrl(publicConfig.customLogoUrl)
         : (publicInfo.thumb ? resolvePortalAssetUrl(publicInfo.thumb) : '');
+    const splashBackgroundUrl = publicConfig?.backgroundImageUrl ? resolvePortalAssetUrl(publicConfig.backgroundImageUrl) : undefined;
 
     return (
         <div className="relative min-h-screen w-full flex flex-col items-center justify-center p-4 sm:p-6 md:p-8 lg:p-10 overflow-hidden">
-            <AuthPageBackground />
+            <AuthPageBackground backgroundImageUrl={splashBackgroundUrl} />
             <Loader isLoading={isLoading} />
 
             <div className="relative z-10 w-full max-w-6xl flex flex-col gap-6">
@@ -3217,12 +3346,12 @@ export const Login: React.FC<{ onLoginSuccess: () => void, publicConfig?: any, i
 
                     <div className={`flex flex-col justify-center items-center text-center p-6 sm:p-8 lg:p-10 xl:p-12 min-w-0 ${showTrialAccess ? 'flex-1' : 'w-full py-10 sm:py-12'}`}>
                         <div className="relative mb-8">
-                            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-36 h-36 bg-plex/20 rounded-full blur-[60px] pointer-events-none" />
+                            {!logoSrc && <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-36 h-36 bg-plex/20 rounded-full blur-[60px] pointer-events-none" />}
                             {logoSrc ? (
                                 <img
                                     src={logoSrc}
                                     alt="Server Logo"
-                                    className="w-28 h-28 sm:w-32 sm:h-32 object-cover rounded-full border-2 border-plex/40 shadow-[0_0_40px_rgba(229,160,13,0.25)] relative z-10"
+                                    className="w-28 sm:w-32 max-h-32 object-contain relative z-10 drop-shadow-[0_0_28px_rgba(0,0,0,0.65)]"
                                     onError={(e) => {
                                         e.currentTarget.src = logoUrl();
                                         e.currentTarget.className = 'w-28 h-28 sm:w-32 sm:h-32 object-cover rounded-full border-2 border-plex/40 shadow-[0_0_40px_rgba(229,160,13,0.25)] relative z-10';
@@ -3239,7 +3368,9 @@ export const Login: React.FC<{ onLoginSuccess: () => void, publicConfig?: any, i
                                     {publicInfo.serverName}
                                 </h1>
                                 <p className="text-muted text-sm sm:text-base leading-relaxed mb-8 max-w-sm">
-                                    Sign in with Plex to access your portal and manage your subscription.
+                                    {isJellyfinAuth
+                                        ? 'Sign in with your Jellyfin account to access your portal and manage your subscription.'
+                                        : 'Sign in with Plex to access your portal and manage your subscription.'}
                                 </p>
                             </>
                         )}
@@ -3254,12 +3385,82 @@ export const Login: React.FC<{ onLoginSuccess: () => void, publicConfig?: any, i
                             </>
                         )}
 
-                        <button type="button" className={loginSecondaryBtnClass} onClick={handlePlexLogin} disabled={isLoading}>
-                            <img src={logoUrl()} alt="" className="w-5 h-5 object-contain opacity-80" onError={(e) => { e.currentTarget.style.display = 'none'; }} />
-                            Login with Plex
-                        </button>
+                        {isJellyfinAuth ? (
+                            <div className="w-full max-w-sm flex flex-col gap-4 text-left">
+                                <button type="button" className={loginSecondaryBtnClass} onClick={handleJellyfinQuickConnect} disabled={isLoading}>
+                                    <img src={JELLYFIN_ICON_URL} alt="" className="w-5 h-5 object-contain" onError={(e) => { e.currentTarget.style.display = 'none'; }} />
+                                    Login with Jellyfin
+                                </button>
 
-                        {!showTrialAccess && (
+                                {quickConnect && (
+                                    <div className="w-full rounded-xl border border-plex/30 bg-plex/10 p-4 text-center">
+                                        <p className="text-[10px] font-bold text-muted uppercase tracking-[0.14em] mb-2">Quick Connect code</p>
+                                        <div className="font-black text-3xl tracking-[0.18em] text-text tabular-nums mb-3">{quickConnect.code}</div>
+                                        <p className="text-xs text-muted leading-relaxed">
+                                            Approve this code in Jellyfin Quick Connect. This page will finish login automatically.
+                                        </p>
+                                        {quickConnect.jellyfinUrl && (
+                                            <button
+                                                type="button"
+                                                onClick={handleOpenJellyfinQuickConnect}
+                                                className="mt-3 inline-flex items-center justify-center text-xs font-bold text-plex hover:text-text transition"
+                                            >
+                                                Copy code & open Quick Connect
+                                            </button>
+                                        )}
+                                    </div>
+                                )}
+
+                                <button
+                                    type="button"
+                                    className="self-center text-xs font-bold text-muted hover:text-text transition"
+                                    onClick={() => setShowJellyfinPassword((value) => !value)}
+                                >
+                                    {showJellyfinPassword ? 'Hide password login' : 'Use password instead'}
+                                </button>
+
+                                {showJellyfinPassword && (
+                                    <form onSubmit={handleJellyfinLogin} className="w-full flex flex-col gap-3 text-left">
+                                        <label className="flex flex-col gap-1.5">
+                                            <span className="text-[10px] font-bold text-muted uppercase tracking-[0.14em]">Jellyfin username</span>
+                                            <input
+                                                value={jellyfinUsername}
+                                                onChange={(e) => setJellyfinUsername(e.target.value)}
+                                                autoComplete="username"
+                                                className="w-full bg-black/25 border border-white/15 rounded-xl px-4 py-3 text-sm text-text outline-none focus:border-plex/70 focus:ring-2 focus:ring-plex/20 transition"
+                                                placeholder="Username"
+                                                disabled={isLoading}
+                                                required
+                                            />
+                                        </label>
+                                        <label className="flex flex-col gap-1.5">
+                                            <span className="text-[10px] font-bold text-muted uppercase tracking-[0.14em]">Password</span>
+                                            <input
+                                                value={jellyfinPassword}
+                                                onChange={(e) => setJellyfinPassword(e.target.value)}
+                                                type="password"
+                                                autoComplete="current-password"
+                                                className="w-full bg-black/25 border border-white/15 rounded-xl px-4 py-3 text-sm text-text outline-none focus:border-plex/70 focus:ring-2 focus:ring-plex/20 transition"
+                                                placeholder="Password"
+                                                disabled={isLoading}
+                                                required
+                                            />
+                                        </label>
+                                        <button type="submit" className={loginSecondaryBtnClass} disabled={isLoading || !jellyfinUsername.trim() || !jellyfinPassword}>
+                                            <img src={JELLYFIN_ICON_URL} alt="" className="w-5 h-5 object-contain" onError={(e) => { e.currentTarget.style.display = 'none'; }} />
+                                            Login with password
+                                        </button>
+                                    </form>
+                                )}
+                            </div>
+                        ) : (
+                            <button type="button" className={loginSecondaryBtnClass} onClick={handlePlexLogin} disabled={isLoading}>
+                                <img src={logoUrl()} alt="" className="w-5 h-5 object-contain opacity-80" onError={(e) => { e.currentTarget.style.display = 'none'; }} />
+                                Login with Plex
+                            </button>
+                        )}
+
+                        {!showTrialAccess && !isJellyfinAuth && (
                             <div className="w-full mt-10 pt-8 border-t border-white/10">
                                 <LivePlexStats />
                             </div>
@@ -3936,7 +4137,7 @@ const WrapUpModal: React.FC<{ metric: string; analytics: any; days: number | str
 };
 
 const DiscoverPosterCard: React.FC<{
-    item: { title: string; thumb?: string; plexUrl: string; tags?: string[]; year?: number | string; parentTitle?: string };
+    item: { title: string; thumb?: string; thumbUrl?: string; plexUrl: string; tags?: string[]; year?: number | string; parentTitle?: string };
     aspect?: '2/3' | 'square';
     overlay?: React.ReactNode;
     variant?: 'discover' | 'home';
@@ -3959,7 +4160,7 @@ const DiscoverPosterCard: React.FC<{
             <div className={`${posterShell} ${aspect === 'square' ? 'aspect-square' : 'aspect-[2/3]'} w-full`}>
                 {item.thumb ? (
                     <img
-                        src={portalUrl(`/api/plex/image?path=${encodeURIComponent(item.thumb)}&width=300&height=${aspect === 'square' ? 300 : 450}`)}
+                        src={item.thumbUrl ? resolvePortalAssetUrl(item.thumbUrl) : portalUrl(`/api/plex/image?path=${encodeURIComponent(item.thumb)}&width=300&height=${aspect === 'square' ? 300 : 450}`)}
                         alt={item.title}
                         loading="lazy"
                         className={`w-full h-full object-cover ${variant === 'home' ? 'transition-[transform,opacity] duration-300 group-hover:scale-105 group-hover:opacity-80' : ''}`}
@@ -4053,7 +4254,56 @@ export const UserDashboard: React.FC<{ sessionInfo: any; publicConfig?: any; onL
 
     const user = sessionInfo.account;
     const showQualityBadges = publicConfig?.showPosterQualityBadges !== false;
+    const isJellyfinPortal = String(publicConfig?.mediaServerType || 'plex').toLowerCase() === 'jellyfin';
     const [optOutNewsletter, setOptOutNewsletter] = useState(user?.optOutNewsletter || false);
+
+    const resolveHomeImage = (thumbUrl: string | null | undefined, fallback = logoUrl()) => {
+        if (!thumbUrl) return fallback;
+        if (thumbUrl.startsWith('http://') || thumbUrl.startsWith('https://') || thumbUrl.startsWith('/api/')) {
+            return resolvePortalAssetUrl(thumbUrl);
+        }
+        return portalUrl(`/api/plex/image?path=${encodeURIComponent(thumbUrl)}&width=256&height=256`);
+    };
+
+    const buildJellyfinHomeAnalytics = (data: any) => {
+        const topMovies = Array.isArray(data?.topMovies) ? data.topMovies : [];
+        const topShows = Array.isArray(data?.topShows) ? data.topShows : [];
+        const topMusic = Array.isArray(data?.topMusic) ? data.topMusic : [];
+        const topWatched = [...topShows, ...topMovies, ...topMusic].sort((a: any, b: any) => (b.plays || 0) - (a.plays || 0));
+        const peakHours = Array.isArray(data?.peakHours) ? data.peakHours : [];
+        const peakHour = peakHours.reduce((best: number, value: number, hour: number) => value > (peakHours[best] || 0) ? hour : best, 0);
+        const moviesCount = data?.jellystatInsights?.moviePlays || topMovies.reduce((sum: number, item: any) => sum + (item.plays || 0), 0);
+        const showsCount = data?.jellystatInsights?.tvPlays || topShows.reduce((sum: number, item: any) => sum + (item.plays || 0), 0);
+        const musicCount = data?.jellystatInsights?.musicPlays || topMusic.reduce((sum: number, item: any) => sum + (item.plays || 0), 0);
+        const topMovie = topMovies[0] || null;
+        const topBinge = topShows[0] || null;
+        const topLibraries = Array.isArray(data?.topLibraries) ? data.topLibraries : [];
+
+        return {
+            totalPlays: data?.totalPlaybacks || data?.jellystatInsights?.totalPlays || 0,
+            moviesCount,
+            showsCount,
+            musicCount,
+            topWatched,
+            recentHistory: [],
+            topMovie: topMovie ? { ...topMovie, artUrl: topMovie.thumbUrl } : null,
+            topBinge: topBinge ? { ...topBinge, artUrl: topBinge.thumbUrl } : null,
+            peakHour,
+            avgHour: peakHour,
+            timeOfDay: peakHour >= 5 && peakHour < 12 ? 'Early Bird' : peakHour >= 12 && peakHour < 18 ? 'Afternoon Watcher' : peakHour >= 18 ? 'Evening Streamer' : 'Night Owl',
+            popularDay: 'Recent Activity',
+            dayOfWeekCounts: {},
+            favoriteLibrary: topLibraries[0]?.title || 'None',
+            topLibraries,
+            mediaPreference: moviesCount > showsCount ? 'Movie Fan' : 'TV Binger',
+            watchStyle: topWatched.length >= 10 ? 'Explorer' : 'Focused',
+            uniqueTitles: topWatched.length,
+            streamingHabit: 'Jellyfin Viewer',
+            weekdayPlays: data?.totalPlaybacks || 0,
+            weekendPlays: 0,
+            libraryHealth: data?.libraryHealth || null,
+        };
+    };
 
     const handleToggleNewsletter = async () => {
         setIsLoading(true);
@@ -4112,7 +4362,9 @@ export const UserDashboard: React.FC<{ sessionInfo: any; publicConfig?: any; onL
             try {
                 setAnalyticsLoading(true);
                 setAnalyticsError(null);
-                const res = await apiFetch(`/api/plex/analytics/me?days=${analyticsDays}`);
+                const res = isJellyfinPortal
+                    ? buildJellyfinHomeAnalytics(await apiFetch(`/api/jellystat/analytics?days=${analyticsDays}`))
+                    : await apiFetch(`/api/plex/analytics/me?days=${analyticsDays}`);
                 if (cancelled) return;
                 setAnalytics(res);
                 setTopContentPage(0);
@@ -4130,7 +4382,7 @@ export const UserDashboard: React.FC<{ sessionInfo: any; publicConfig?: any; onL
         };
         fetchAnalytics();
         return () => { cancelled = true; };
-    }, [user, sessionInfo.session.isAdmin, analyticsDays]);
+    }, [user, sessionInfo.session.isAdmin, analyticsDays, isJellyfinPortal]);
 
     useEffect(() => {
         const mq = window.matchMedia('(min-width: 1024px)');
@@ -4160,7 +4412,7 @@ export const UserDashboard: React.FC<{ sessionInfo: any; publicConfig?: any; onL
         const fetchDashboard = async () => {
             if (!isMounted) return;
             try {
-                const res = await apiFetch(`/api/plex/dashboard?limit=${RECENTLY_ADDED_ITEM_LIMIT}`);
+                const res = await apiFetch(`${isJellyfinPortal ? '/api/jellyfin/dashboard' : '/api/plex/dashboard'}?limit=${RECENTLY_ADDED_ITEM_LIMIT}`);
                 if (isMounted) setDashboardData(res);
             } catch (e) {
                 console.error('Failed to refresh dashboard data', e);
@@ -4170,14 +4422,16 @@ export const UserDashboard: React.FC<{ sessionInfo: any; publicConfig?: any; onL
         const fetchServerData = async () => {
             if (!isMounted) return;
             try {
-                const p1 = apiFetch('/api/plex/stats').then(res => {
-                    if (isMounted) {
-                        setServerStats(res);
-                        if (res?.isBuilding) {
-                            pollTimer = setTimeout(fetchServerData, 5000);
+                const p1 = isJellyfinPortal
+                    ? Promise.resolve({ provider: 'jellyfin' }).then(res => { if (isMounted) setServerStats(res); })
+                    : apiFetch('/api/plex/stats').then(res => {
+                        if (isMounted) {
+                            setServerStats(res);
+                            if (res?.isBuilding) {
+                                pollTimer = setTimeout(fetchServerData, 5000);
+                            }
                         }
-                    }
-                }).catch(e => console.error("Failed to fetch server stats", e));
+                    }).catch(e => console.error("Failed to fetch server stats", e));
 
                 const p2 = fetchDashboard();
                 await Promise.all([p1, p2]);
@@ -4192,7 +4446,16 @@ export const UserDashboard: React.FC<{ sessionInfo: any; publicConfig?: any; onL
             if (pollTimer) clearTimeout(pollTimer);
             if (dashboardTimer) clearInterval(dashboardTimer);
         };
-    }, []);
+    }, [isJellyfinPortal]);
+
+    useEffect(() => {
+        if (!isJellyfinPortal || !analytics?.libraryHealth) return;
+        setServerStats((current: any) => ({
+            ...(current || {}),
+            provider: 'jellyfin',
+            ...analytics.libraryHealth,
+        }));
+    }, [isJellyfinPortal, analytics?.libraryHealth]);
 
     const handleRelink = async () => {
         setIsLoading(true);
@@ -4282,8 +4545,8 @@ export const UserDashboard: React.FC<{ sessionInfo: any; publicConfig?: any; onL
                         <div className="absolute -inset-[50%] opacity-40 transform -rotate-12 scale-110 flex gap-4 overflow-hidden pointer-events-none justify-center">
                             {[...Array(6)].map((_, colIdx) => (
                                 <div key={colIdx} className={`flex flex-col gap-4 ${colIdx % 2 === 0 ? 'animate-[scrollVertical_40s_linear_infinite]' : 'animate-[scrollVertical_50s_linear_infinite_reverse]'}`}>
-                                    {[...dashboardData.recentMovies, ...dashboardData.recentMovies].sort(() => 0.5 - Math.random()).map((m: any, i: number) => m.thumb && (
-                                        <img key={`c${colIdx}-${i}`} src={portalUrl(`/api/plex/image?path=${encodeURIComponent(m.thumb)}&width=200&height=300`)} className="w-32 md:w-48 rounded-xl object-cover" alt="" />
+                                    {[...dashboardData.recentMovies, ...dashboardData.recentMovies].sort(() => 0.5 - Math.random()).map((m: any, i: number) => (m.thumb || m.thumbUrl) && (
+                                        <img key={`c${colIdx}-${i}`} src={m.thumbUrl ? resolvePortalAssetUrl(m.thumbUrl) : portalUrl(`/api/plex/image?path=${encodeURIComponent(m.thumb)}&width=200&height=300`)} className="w-32 md:w-48 rounded-xl object-cover" alt="" />
                                     ))}
                                 </div>
                             ))}
@@ -4307,7 +4570,7 @@ export const UserDashboard: React.FC<{ sessionInfo: any; publicConfig?: any; onL
                                 return (
                                     <div className="relative">
                                         <img
-                                            src={thumbUrl.startsWith('http') ? thumbUrl : portalUrl(`/api/plex/image?path=${encodeURIComponent(thumbUrl)}&width=256&height=256`)}
+                                            src={resolveHomeImage(thumbUrl)}
                                             alt={sessionInfo.session.username}
                                             className="relative w-28 h-28 md:w-32 md:h-32 rounded-full object-cover border-4 border-plex shadow-2xl bg-card"
                                             onError={(e) => {
@@ -4885,10 +5148,14 @@ export const StatusDashboard: React.FC<{ onBack: () => void, isAdmin: boolean, i
         </div>
     );
 };
-const StreamDetailsModal: React.FC<{ session: any, onClose: () => void, isAdmin?: boolean, onKilled?: () => void }> = ({ session, onClose, isAdmin, onKilled }) => {
+const StreamDetailsModal: React.FC<{ session: any, onClose: () => void, isAdmin?: boolean, onKilled?: () => void, providerLabel?: string }> = ({ session, onClose, isAdmin, onKilled, providerLabel = 'Plex' }) => {
     const [killReason, setKillReason] = useState('');
     const [isKilling, setIsKilling] = useState(false);
     const [showKillConfirm, setShowKillConfirm] = useState(false);
+    const sessionPosterSrc = session.thumbUrl
+        ? resolvePortalAssetUrl(session.thumbUrl)
+        : portalUrl(`/api/plex/image?path=${encodeURIComponent(session.thumb)}&width=400&height=600`);
+    const sessionUserThumbSrc = session.userThumb ? resolvePortalAssetUrl(session.userThumb) : 'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y';
 
     const handleKill = async () => {
         setIsKilling(true);
@@ -4916,13 +5183,13 @@ const StreamDetailsModal: React.FC<{ session: any, onClose: () => void, isAdmin?
                 {/* Poster Side */}
                 <div className="w-full md:w-1/3 relative bg-black flex-shrink-0">
                     <div className="w-full pb-[150%] md:pb-0 md:h-full relative">
-                        <img src={portalUrl(`/api/plex/image?path=${encodeURIComponent(session.thumb)}&width=400&height=600`)} alt={session.title} className="absolute inset-0 w-full h-full object-cover opacity-80" />
+                        <img src={sessionPosterSrc} alt={session.title} className="absolute inset-0 w-full h-full object-cover opacity-80" />
                         <div className="absolute inset-0 bg-gradient-to-t from-card to-transparent md:bg-gradient-to-r"></div>
                     </div>
                     {/* User Avatar Badge */}
                     {session.user && (
                         <div className="absolute top-4 left-4 flex items-center gap-2 bg-black/60 backdrop-blur-md rounded-full pr-4 p-1.5 shadow-lg border border-white/10 z-10">
-                            <img src={session.userThumb ? session.userThumb : 'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y'} className="w-8 h-8 rounded-full object-cover" onError={(e) => { e.currentTarget.src = 'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y'; }} />
+                            <img src={sessionUserThumbSrc} className="w-8 h-8 rounded-full object-cover" onError={(e) => { e.currentTarget.src = 'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y'; }} />
                             <span className="text-xs font-bold text-white truncate max-w-[120px]">{session.user}</span>
                         </div>
                     )}
@@ -4988,7 +5255,7 @@ const StreamDetailsModal: React.FC<{ session: any, onClose: () => void, isAdmin?
                             )
                         )}
                         <a href={session.plexUrl} target="_blank" rel="noreferrer" className="flex-1 bg-plex text-background font-bold text-center py-3 rounded-lg hover:bg-plex-hover transition-colors shadow-lg">
-                            Open in Plex
+                            Open in {providerLabel}
                         </a>
                     </div>
                 </div>
@@ -4997,7 +5264,7 @@ const StreamDetailsModal: React.FC<{ session: any, onClose: () => void, isAdmin?
     );
 };
 
-export const LibraryDashboard: React.FC<{ onBack: () => void, isAdmin?: boolean, publicConfig?: any }> = ({ onBack, isAdmin, publicConfig }) => {
+export const LibraryDashboard: React.FC<{ onBack: () => void, isAdmin?: boolean, publicConfig?: any, mediaServerType?: string }> = ({ onBack, isAdmin, publicConfig, mediaServerType }) => {
     const [dashboardData, setDashboardData] = useState<{ activeSessions: any[], recentMovies: any[], recentShows: any[], recentMusic: any[] } | null>(null);
     const [trendingStats, setTrendingStats] = useState<{ trending7Days: any[], movies30Days: any[], shows30Days: any[], top365Days: any[], allTime: any[], weekendWarriors: any[], nightOwls: any[], retroHits: any[], cultClassics: any[] } | null>(null);
     const [dashboardLoading, setDashboardLoading] = useState(true);
@@ -5016,6 +5283,7 @@ export const LibraryDashboard: React.FC<{ onBack: () => void, isAdmin?: boolean,
     const recentLimit = recentLimitOverride ?? responsiveRecentLimit;
     const [selectedSession, setSelectedSession] = useState<any | null>(null);
     const showQualityBadges = publicConfig?.showPosterQualityBadges !== false;
+    const isJellyfinPortal = String(publicConfig?.mediaServerType || mediaServerType || 'plex').toLowerCase() === 'jellyfin';
     const hasLoadedDashboard = useRef(false);
     const hasLoadedTrending = useRef(false);
 
@@ -5026,6 +5294,16 @@ export const LibraryDashboard: React.FC<{ onBack: () => void, isAdmin?: boolean,
         return () => mq.removeEventListener('change', onChange);
     }, []);
 
+    useEffect(() => {
+        if (!isJellyfinPortal) return;
+        setDashboardData({ activeSessions: [], recentMovies: [], recentShows: [], recentMusic: [] });
+        setTrendingStats(null);
+        setError(null);
+        setPollError(null);
+        setDashboardLoading(false);
+        setTrendingLoading(false);
+    }, [isJellyfinPortal]);
+
     const handleRecentLimitChange = useCallback((value: string) => {
         const next = Number(value);
         setRecentLimitOverride(next);
@@ -5035,7 +5313,7 @@ export const LibraryDashboard: React.FC<{ onBack: () => void, isAdmin?: boolean,
 
     const fetchDashboardOnly = useCallback(async () => {
         try {
-            const res = await apiFetch(`/api/plex/dashboard?limit=${recentLimit}`);
+            const res = await apiFetch(`${isJellyfinPortal ? '/api/jellyfin/dashboard' : '/api/plex/dashboard'}?limit=${recentLimit}`);
             if (res.error) {
                 setPollError(res.error);
                 return;
@@ -5045,14 +5323,14 @@ export const LibraryDashboard: React.FC<{ onBack: () => void, isAdmin?: boolean,
         } catch (err: any) {
             setPollError(err?.message || 'Live dashboard update failed');
         }
-    }, [recentLimit]);
+    }, [recentLimit, isJellyfinPortal]);
 
     const fetchData = useCallback(async () => {
         setError(null);
         if (!hasLoadedDashboard.current) setDashboardLoading(true);
-        if (!hasLoadedTrending.current) setTrendingLoading(true);
+        if (!isJellyfinPortal && !hasLoadedTrending.current) setTrendingLoading(true);
         try {
-            const res = await apiFetch(`/api/plex/dashboard?limit=${recentLimit}`);
+            const res = await apiFetch(`${isJellyfinPortal ? '/api/jellyfin/dashboard' : '/api/plex/dashboard'}?limit=${recentLimit}`);
             if (res.error) throw new Error(res.error);
             setDashboardData(res);
         } catch (err: any) {
@@ -5060,6 +5338,13 @@ export const LibraryDashboard: React.FC<{ onBack: () => void, isAdmin?: boolean,
         } finally {
             hasLoadedDashboard.current = true;
             setDashboardLoading(false);
+        }
+
+        if (isJellyfinPortal) {
+            setTrendingStats(null);
+            hasLoadedTrending.current = true;
+            setTrendingLoading(false);
+            return;
         }
 
         try {
@@ -5073,7 +5358,7 @@ export const LibraryDashboard: React.FC<{ onBack: () => void, isAdmin?: boolean,
             hasLoadedTrending.current = true;
             setTrendingLoading(false);
         }
-    }, [recentLimit]);
+    }, [recentLimit, isJellyfinPortal]);
 
     useEffect(() => {
         fetchData();
@@ -5128,16 +5413,20 @@ export const LibraryDashboard: React.FC<{ onBack: () => void, isAdmin?: boolean,
                             <div className={activityStreamGridClass(isWidePortalLayout, dashboardData.activeSessions.length)}>
                                 {dashboardData.activeSessions.map((session, i) => {
                                     const activityCols = activityStreamColumnCount(isWidePortalLayout, dashboardData.activeSessions.length);
+                                    const sessionPosterSrc = session.thumbUrl
+                                        ? resolvePortalAssetUrl(session.thumbUrl)
+                                        : portalUrl(`/api/plex/image?path=${encodeURIComponent(session.thumb)}&width=300&height=500`);
+                                    const sessionUserThumbSrc = session.userThumb ? resolvePortalAssetUrl(session.userThumb) : 'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y';
                                     return (
                                         <div key={session.sessionId ?? i} onClick={() => setSelectedSession(session)} className="bg-card rounded-xl border border-border flex flex-col overflow-hidden shadow-lg hover:border-plex/50 hover:shadow-plex/20 transition-all cursor-pointer select-none h-full min-h-[11.5rem] md:min-h-[14.5rem]">
                                             <div className="flex flex-row flex-1 items-stretch min-h-0">
                                                 <div className={`${activityCols === 4 ? 'w-28 md:w-32' : 'w-32 md:w-40'} flex-shrink-0 relative overflow-hidden bg-card self-stretch`}>
-                                                    <img src={portalUrl(`/api/plex/image?path=${encodeURIComponent(session.thumb)}&width=300&height=500`)} alt={session.title} loading="lazy" className="absolute inset-0 w-full h-full object-cover object-top drop-shadow-2xl" />
+                                                    <img src={sessionPosterSrc} alt={session.title} loading="lazy" className="absolute inset-0 w-full h-full object-cover object-top drop-shadow-2xl" />
                                                 </div>
                                                 <div className="p-2 md:p-3 flex flex-col flex-1 min-w-0 relative">
                                                     {session.user && (
                                                         <div className="absolute top-2 right-2 flex items-center gap-1.5 bg-black/50 backdrop-blur-md rounded-full pr-2.5 p-0.5 shadow-md border border-white/5">
-                                                            <img src={session.userThumb ? session.userThumb : 'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y'} alt={session.user} className="w-5 h-5 rounded-full object-cover" onError={(e) => { e.currentTarget.src = 'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y'; }} />
+                                                            <img src={sessionUserThumbSrc} alt={session.user} className="w-5 h-5 rounded-full object-cover" onError={(e) => { e.currentTarget.src = 'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y'; }} />
                                                             <span className="text-[10px] font-bold text-white/90 truncate max-w-[80px] md:max-w-[100px]">{session.user}</span>
                                                         </div>
                                                     )}
@@ -5255,12 +5544,12 @@ export const LibraryDashboard: React.FC<{ onBack: () => void, isAdmin?: boolean,
 
                     {/* RECENT TV SHOWS */}
                     <div className="flex flex-col">
-                        <h2 className="text-plex text-sm uppercase tracking-[2px] mb-6 font-bold border-b border-white/10 pb-2">RECENTLY ADDED TV SHOWS</h2>
+                        <h2 className="text-plex text-sm uppercase tracking-[2px] mb-6 font-bold border-b border-white/10 pb-2">{isJellyfinPortal ? 'RECENTLY ADDED EPISODES' : 'RECENTLY ADDED TV SHOWS'}</h2>
                         <div className={discoverPosterGridClass}>
                             {dashboardData && dashboardData.recentShows.slice(0, recentLimit).map((item, i) => (
                                 <DiscoverPosterCard key={i} item={item} showQualityBadges={showQualityBadges} />
                             ))}
-                            {(!dashboardData || dashboardData.recentShows.length === 0) && <div className="text-center text-muted p-8 border border-dashed border-border rounded-xl mt-4 w-full col-span-full">No recent TV shows</div>}
+                            {(!dashboardData || dashboardData.recentShows.length === 0) && <div className="text-center text-muted p-8 border border-dashed border-border rounded-xl mt-4 w-full col-span-full">{isJellyfinPortal ? 'No recent episodes' : 'No recent TV shows'}</div>}
                         </div>
                     </div>
 
@@ -5277,9 +5566,9 @@ export const LibraryDashboard: React.FC<{ onBack: () => void, isAdmin?: boolean,
                 </div>
 
                 {/* SERVER WIDE STATS SECTION */}
-                {trendingLoading && !trendingStats ? (
+                {!isJellyfinPortal && trendingLoading && !trendingStats ? (
                     <TrendingSectionsSkeleton count={trendingCount} sections={3} />
-                ) : trendingStats && (
+                ) : !isJellyfinPortal && trendingStats && (
                     <div className="mt-16 w-full flex flex-col gap-12">
                         <div className="flex flex-col gap-2 items-center text-center mb-4">
                             <h2 className="text-3xl md:text-4xl font-extrabold text-white tracking-tight">Other things happening on {publicConfig?.serverIdentifier || 'this server'}</h2>
@@ -5300,7 +5589,7 @@ export const LibraryDashboard: React.FC<{ onBack: () => void, isAdmin?: boolean,
             </main>
 
             {/* Stream Details Modal */}
-            {selectedSession && <StreamDetailsModal session={selectedSession} onClose={() => setSelectedSession(null)} isAdmin={isAdmin} onKilled={fetchData} />}
+            {selectedSession && <StreamDetailsModal session={selectedSession} onClose={() => setSelectedSession(null)} isAdmin={isAdmin} onKilled={fetchData} providerLabel={isJellyfinPortal ? 'Jellyfin' : 'Plex'} />}
         </div>
     );
 };
@@ -6555,15 +6844,17 @@ interface NavigationProps {
     isAdmin: boolean;
     serverName: string;
     adminThumb?: string | null;
+    customLogoUrl?: string | null;
     requestUrl: string;
     navOrder: string[];
     appVersion?: string;
 }
 
-export const Navigation: React.FC<NavigationProps> = ({ currentRoute, onNavigate, onLogout, isAdmin, serverName, adminThumb, requestUrl, navOrder, appVersion }) => {
+export const Navigation: React.FC<NavigationProps> = ({ currentRoute, onNavigate, onLogout, isAdmin, serverName, adminThumb, customLogoUrl, requestUrl, navOrder, appVersion }) => {
+    const serverIcon = customLogoUrl ? resolvePortalAssetUrl(customLogoUrl) : (adminThumb ? (adminThumb.startsWith('http') ? adminThumb : portalUrl(`/api/plex/image?path=${encodeURIComponent(adminThumb)}&width=256&height=256`)) : logoUrl());
     useEffect(() => {
-        updateFavicon(adminThumb);
-    }, [adminThumb]);
+        updateFavicon(serverIcon);
+    }, [serverIcon]);
 
     const navItemsConfig: Record<string, { label: string; icon: React.FC<any>; route: string; adminOnly: boolean; href?: string; onClick?: (e: any) => void }> = {
         'home': { label: 'Home', icon: Home, route: 'user', adminOnly: false },
@@ -6595,9 +6886,9 @@ export const Navigation: React.FC<NavigationProps> = ({ currentRoute, onNavigate
             <div className="md:hidden fixed top-0 left-0 right-0 h-16 nav-shell border-b z-50 flex items-center justify-between px-4 shadow-lg">
                 <div className="flex items-center gap-3">
                     <img
-                        src={adminThumb ? (adminThumb.startsWith('http') ? adminThumb : portalUrl(`/api/plex/image?path=${encodeURIComponent(adminThumb)}&width=64&height=64`)) : logoUrl()}
+                        src={serverIcon}
                         alt="Logo"
-                        className="w-8 h-8 rounded-full object-cover"
+                        className={`w-8 h-8 ${customLogoUrl ? 'object-contain' : 'rounded-full object-cover'}`}
                         onError={(e) => {
                             (e.target as HTMLImageElement).src = logoUrl();
                         }}
@@ -6645,7 +6936,18 @@ export const Navigation: React.FC<NavigationProps> = ({ currentRoute, onNavigate
                 </div>
 
                 <div className="flex flex-col items-center mt-auto pt-10 pb-4 group cursor-default">
-                    <div className="relative mb-6">
+                    <div className={`relative mb-6 ${customLogoUrl ? 'w-32 flex items-center justify-center' : ''}`}>
+                        {customLogoUrl ? (
+                            <img
+                                src={serverIcon}
+                                alt="Server Logo"
+                                className="max-w-32 max-h-32 object-contain drop-shadow-[0_0_24px_rgba(0,0,0,0.75)] group-hover:scale-105 transition-transform duration-700 ease-out"
+                                onError={(e) => {
+                                    (e.target as HTMLImageElement).src = logoUrl();
+                                }}
+                            />
+                        ) : (
+                            <>
                         {/* Soft ambient background glow */}
                         <div className="absolute inset-0 bg-plex blur-[25px] opacity-20 group-hover:opacity-40 transition-opacity duration-700 rounded-full"></div>
                         {/* Spinning gradient border */}
@@ -6654,15 +6956,17 @@ export const Navigation: React.FC<NavigationProps> = ({ currentRoute, onNavigate
                         <div className="relative w-28 h-28 rounded-full p-[4px] shadow-2xl bg-card">
                             <div className="w-full h-full rounded-full overflow-hidden bg-background">
                                 <img
-                                    src={adminThumb ? (adminThumb.startsWith('http') ? adminThumb : portalUrl(`/api/plex/image?path=${encodeURIComponent(adminThumb)}&width=256&height=256`)) : logoUrl()}
+                                    src={serverIcon}
                                     alt="Server Logo"
-                                    className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700 ease-out"
+                                    className={`w-full h-full group-hover:scale-110 transition-transform duration-700 ease-out ${customLogoUrl ? 'object-contain p-3' : 'object-cover'}`}
                                     onError={(e) => {
                                         (e.target as HTMLImageElement).src = logoUrl();
                                     }}
                                 />
                             </div>
                         </div>
+                            </>
+                        )}
                     </div>
 
                     <div className="flex flex-col items-center text-center px-2">

--- a/client/settings/SettingsDashboard.tsx
+++ b/client/settings/SettingsDashboard.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Copy, ChevronUp, ChevronDown, Check } from 'lucide-react';
 import { apiFetch } from '../shared/api';
-import { portalUrl } from '../shared/basePath';
+import { portalUrl, resolvePortalAssetUrl } from '../shared/basePath';
 import { appConfirm } from '../shared/confirm';
 import { CustomSelect } from '../shared/ui';
 import { Loader, ToastContainer, pushToast, type ToastMessage } from '../shared/toast';
 import { SettingHint } from './SettingHint';
-import type { User, AuditEntry, DeletedUser } from '../shared/types';
-import { formatDateTime, formatEventName, hexToRgb, getDaysUntilExpiry, addMonths, addYears, formatDate } from '../shared/format';
+import type { User, AuditEntry, DeletedUser, PlexServer } from '../shared/types';
+import { formatDateTime, formatEventName, hexToRgb, accentHoverRgb, getDaysUntilExpiry, addMonths, addYears, formatDate } from '../shared/format';
 
 import { StreamKillRulesPanel } from './StreamKillRulesPanel';
 import { InvitesSettings } from './InvitesSettings';
@@ -26,6 +26,64 @@ const hasIntegrationCredentials = (
     const effectiveUrl = String(url || savedUrl || '').trim();
     const effectiveKey = String(apiKey || savedApiKey || '').trim();
     return Boolean(effectiveUrl && effectiveKey);
+};
+
+const SELFHST_ICON_BASE = 'https://cdn.jsdelivr.net/gh/selfhst/icons/svg';
+const APP_ICONS: Record<string, string> = {
+    sonarr: `${SELFHST_ICON_BASE}/sonarr.svg`,
+    radarr: `${SELFHST_ICON_BASE}/radarr.svg`,
+    tautulli: `${SELFHST_ICON_BASE}/tautulli.svg`,
+    seerr: `${SELFHST_ICON_BASE}/seerr.svg`,
+    overseerr: `${SELFHST_ICON_BASE}/seerr.svg`,
+    jellyseerr: `${SELFHST_ICON_BASE}/jellyseerr.svg`,
+    ombi: `${SELFHST_ICON_BASE}/ombi.svg`,
+    jellystat: 'https://cdn.jsdelivr.net/gh/selfhst/icons@main/png/jellystat.png',
+};
+
+const ProgramIcon: React.FC<{ app: string; label: string }> = ({ app, label }) => (
+    <span className="w-9 h-9 rounded-lg bg-white/5 border border-white/10 flex items-center justify-center overflow-hidden flex-shrink-0">
+        {APP_ICONS[app] ? (
+            <img
+                src={APP_ICONS[app]}
+                alt=""
+                className="w-6 h-6 object-contain"
+                onError={(e) => { e.currentTarget.style.display = 'none'; }}
+            />
+        ) : (
+            <span className="text-[10px] font-black text-plex">{label.slice(0, 2).toUpperCase()}</span>
+        )}
+        <span className="sr-only">{label}</span>
+    </span>
+);
+
+const IntegrationHeading: React.FC<{ app: string; title: string; subtitle?: string; className?: string }> = ({ app, title, subtitle, className = '' }) => (
+    <div className={`flex items-center gap-3 border-b border-border pb-3 mb-4 ${className}`}>
+        <ProgramIcon app={app} label={title} />
+        <div>
+            <h3 className="text-xl font-bold text-text leading-tight">{title}</h3>
+            {subtitle && <p className="text-xs text-muted mt-0.5">{subtitle}</p>}
+        </div>
+    </div>
+);
+
+const BRAND_THEME_OPTIONS = [
+    { label: 'Plex', value: 'plex' },
+    { label: 'Jellyfin', value: 'jellyfin' },
+    { label: 'Custom', value: 'custom' },
+];
+
+const BRAND_THEME_COLORS: Record<string, string> = {
+    plex: '#F7C600',
+    jellyfin: '#00A4DC',
+};
+const JELLYFIN_BRAND_LOGO_URL = '/api/jellyfin/branding/icon';
+const JELLYFIN_BRAND_BACKGROUND_URL = '/api/jellyfin/branding/splash';
+
+const inferBrandTheme = (color = '') => {
+    const normalized = color.trim().toUpperCase();
+    if (normalized === BRAND_THEME_COLORS.plex) return 'plex';
+    if (normalized === BRAND_THEME_COLORS.jellyfin) return 'jellyfin';
+    return 'custom';
 };
 
 export const SettingsDashboard: React.FC = () => {
@@ -94,7 +152,10 @@ export const SettingsDashboard: React.FC = () => {
         }
     };
     const [token, setToken] = useState('');
+    const [mediaServerType, setMediaServerType] = useState<'plex' | 'jellyfin'>('plex');
     const [plexServerUrl, setPlexServerUrl] = useState('');
+    const [jellyfinUrl, setJellyfinUrl] = useState('');
+    const [jellyfinApiKey, setJellyfinApiKey] = useState('');
     const [servers, setServers] = useState<PlexServer[]>([]);
     const [selectedServer, setSelectedServer] = useState('');
     const [checkInterval, setCheckInterval] = useState(60);
@@ -121,8 +182,8 @@ export const SettingsDashboard: React.FC = () => {
         {
             title: 'Integrations',
             tabs: [
-                { id: 'plex', label: 'Plex Integration', keywords: ['token', 'server', 'libraries', 'docker', 'local', 'url', 'direct'] },
-                { id: 'mediastack', label: 'Media Stack', keywords: ['sonarr', 'radarr', 'tautulli'] },
+                { id: 'plex', label: 'Media Player', keywords: ['plex', 'jellyfin', 'media', 'player', 'token', 'server', 'libraries', 'docker', 'local', 'url', 'direct'] },
+                { id: 'mediastack', label: 'Media Stack', keywords: ['sonarr', 'radarr', 'tautulli', 'jellystat', 'seerr', 'jellyseerr'] },
                 { id: 'status', label: 'Status Monitor', keywords: ['uptime', 'health', 'services'] }
             ]
         },
@@ -224,6 +285,8 @@ export const SettingsDashboard: React.FC = () => {
     const [radarrApiKey, setRadarrApiKey] = useState('');
     const [tautulliUrl, setTautulliUrl] = useState('');
     const [tautulliApiKey, setTautulliApiKey] = useState('');
+    const [jellystatUrl, setJellystatUrl] = useState('');
+    const [jellystatApiKey, setJellystatApiKey] = useState('');
     const [requestAppType, setRequestAppType] = useState('none');
     const [requestAppUrl, setRequestAppUrl] = useState('');
     const [requestAppApiKey, setRequestAppApiKey] = useState('');
@@ -237,8 +300,10 @@ export const SettingsDashboard: React.FC = () => {
     }, []);
 
     // Branding & UI States
-    const [primaryColor, setPrimaryColor] = useState('#E5A00D');
+    const [brandTheme, setBrandTheme] = useState('plex');
+    const [primaryColor, setPrimaryColor] = useState(BRAND_THEME_COLORS.plex);
     const [customLogoUrl, setCustomLogoUrl] = useState('');
+    const [backgroundImageUrl, setBackgroundImageUrl] = useState('');
     const [referralEnabled, setReferralEnabled] = useState(false);
     const [referralTrialDays, setReferralTrialDays] = useState(3);
     const [referralRewardDays, setReferralRewardDays] = useState(7);
@@ -445,12 +510,18 @@ export const SettingsDashboard: React.FC = () => {
         );
     };
 
-    const trackedIntegrationKeys = ['plexConfigured', 'sonarrConfigured', 'radarrConfigured', 'tautulliConfigured', 'requestAppConfigured'] as const;
-    const integrationLabels: Record<(typeof trackedIntegrationKeys)[number], string> = {
+    const trackedIntegrationKeys = useMemo(() => {
+        const mediaKey = mediaServerType === 'jellyfin' ? 'jellyfinConfigured' : 'plexConfigured';
+        const analyticsKey = mediaServerType === 'jellyfin' ? 'jellystatConfigured' : 'tautulliConfigured';
+        return [mediaKey, 'sonarrConfigured', 'radarrConfigured', analyticsKey, 'requestAppConfigured'];
+    }, [mediaServerType]);
+    const integrationLabels: Record<string, string> = {
+        jellyfinConfigured: 'Jellyfin',
         plexConfigured: 'Plex',
         sonarrConfigured: 'Sonarr',
         radarrConfigured: 'Radarr',
         tautulliConfigured: 'Tautulli',
+        jellystatConfigured: 'Jellystat',
         requestAppConfigured: 'Request App',
     };
 
@@ -572,8 +643,9 @@ export const SettingsDashboard: React.FC = () => {
             .map((key) => [key, !!integrations[key]] as const);
         const cacheEntries = Object.entries(diagnostics.caches || {}).filter(([key]) => {
             if (!maintenanceExperimentalEnabled) {
-                return !key.startsWith('maintenance');
+                if (key.startsWith('maintenance')) return false;
             }
+            if (mediaServerType === 'jellyfin' && key === 'plexStats') return false;
             return true;
         });
         const cacheValues = cacheEntries.map(([, entry]: any) => !!entry?.exists);
@@ -621,7 +693,7 @@ export const SettingsDashboard: React.FC = () => {
             runningJobs,
             failingJobs
         };
-    }, [diagnostics, maintenanceExperimentalEnabled]);
+    }, [diagnostics, maintenanceExperimentalEnabled, mediaServerType, trackedIntegrationKeys]);
 
     const auditEventsPerPage = 12;
     const totalAuditLogPages = Math.max(1, Math.ceil(auditLogEntries.length / auditEventsPerPage));
@@ -647,7 +719,10 @@ export const SettingsDashboard: React.FC = () => {
     useEffect(() => {
         if (initialSettings) {
             setToken(initialSettings.token || '');
+            setMediaServerType(initialSettings.mediaServerType === 'jellyfin' ? 'jellyfin' : 'plex');
             setPlexServerUrl(initialSettings.plexServerUrl || '');
+            setJellyfinUrl(initialSettings.jellyfinUrl || '');
+            setJellyfinApiKey(initialSettings.jellyfinApiKey || '');
             setSelectedServer(initialSettings.serverIdentifier || '');
             setCheckInterval(initialSettings.checkIntervalMinutes || 60);
             setSmtpHost(initialSettings.smtpHost || '');
@@ -672,11 +747,15 @@ export const SettingsDashboard: React.FC = () => {
             setRadarrApiKey(initialSettings.radarrApiKey || '');
             setTautulliUrl(initialSettings.tautulliUrl || '');
             setTautulliApiKey(initialSettings.tautulliApiKey || '');
-            setRequestAppType(initialSettings.requestAppType || 'none');
+            setJellystatUrl(initialSettings.jellystatUrl || '');
+            setJellystatApiKey(initialSettings.jellystatApiKey || '');
+            setRequestAppType(initialSettings.requestAppType === 'overseerr' ? 'seerr' : (initialSettings.requestAppType || 'none'));
             setRequestAppUrl(initialSettings.requestAppUrl || '');
             setRequestAppApiKey(initialSettings.requestAppApiKey || '');
-            setPrimaryColor(initialSettings.primaryColor || '#E5A00D');
+            setBrandTheme(inferBrandTheme(initialSettings.primaryColor || BRAND_THEME_COLORS.plex));
+            setPrimaryColor(initialSettings.primaryColor || BRAND_THEME_COLORS.plex);
             setCustomLogoUrl(initialSettings.customLogoUrl || '');
+            setBackgroundImageUrl(initialSettings.backgroundImageUrl || '');
             setReferralEnabled(!!initialSettings.referralEnabled);
             setReferralTrialDays(initialSettings.referralTrialDays || 3);
             setReferralRewardDays(initialSettings.referralRewardDays || 7);
@@ -737,8 +816,12 @@ export const SettingsDashboard: React.FC = () => {
             await streamRulesSaveHandlerRef.current();
             return;
         }
-        if (!token || !selectedServer) {
+        if (mediaServerType === 'plex' && (!token || !selectedServer)) {
             addToast('Token and server must be selected.', 'error');
+            return;
+        }
+        if (mediaServerType === 'jellyfin' && (!jellyfinUrl || !hasIntegrationCredentials(jellyfinUrl, jellyfinApiKey, initialSettings.jellyfinUrl, initialSettings.jellyfinApiKey))) {
+            addToast('Jellyfin URL and API key must be set.', 'error');
             return;
         }
 
@@ -761,8 +844,11 @@ export const SettingsDashboard: React.FC = () => {
 
         await handleSaveConfig({
             token,
+            mediaServerType,
             serverIdentifier: selectedServer,
             plexServerUrl: plexServerUrl || '',
+            jellyfinUrl,
+            jellyfinApiKey,
             checkIntervalMinutes: checkInterval,
             smtpHost,
             smtpPort,
@@ -786,11 +872,14 @@ export const SettingsDashboard: React.FC = () => {
             radarrApiKey,
             tautulliUrl,
             tautulliApiKey,
+            jellystatUrl,
+            jellystatApiKey,
             requestAppType,
             requestAppUrl,
             requestAppApiKey,
             primaryColor,
             customLogoUrl,
+            backgroundImageUrl,
             referralEnabled,
             referralTrialDays,
             referralRewardDays,
@@ -809,6 +898,27 @@ export const SettingsDashboard: React.FC = () => {
         });
         document.documentElement.style.setProperty('--color-plex', hexToRgb(primaryColor));
     };
+
+    const applyBrandTheme = (theme: string) => {
+        setBrandTheme(theme);
+        if (theme === 'plex' || theme === 'jellyfin') {
+            setPrimaryColor(BRAND_THEME_COLORS[theme]);
+        }
+    };
+
+    const applyJellyfinBranding = () => {
+        setBrandTheme('jellyfin');
+        setPrimaryColor(BRAND_THEME_COLORS.jellyfin);
+        setCustomLogoUrl(JELLYFIN_BRAND_LOGO_URL);
+        setBackgroundImageUrl(JELLYFIN_BRAND_BACKGROUND_URL);
+        setLogoFile(null);
+        addToast('Jellyfin server icon and splash background applied. Save settings to publish.');
+    };
+
+    useEffect(() => {
+        document.documentElement.style.setProperty('--color-plex', hexToRgb(primaryColor));
+        document.documentElement.style.setProperty('--color-plex-hover', accentHoverRgb(primaryColor));
+    }, [primaryColor]);
 
     const handleTestEmail = async () => {
         if (!smtpHost || !smtpUser || !smtpPass || !testRecipient) {
@@ -939,7 +1049,46 @@ export const SettingsDashboard: React.FC = () => {
     
                         {activeTab === 'plex' && (
                             <div className="mb-8">
-                                <h3 className="text-xl font-bold text-plex mb-4 border-b border-border pb-2">Plex Integration</h3>
+                                <h3 className="text-xl font-bold text-plex mb-4 border-b border-border pb-2">Media Server Integration</h3>
+                                <div className="mb-4">
+                                    <label htmlFor="mediaServerType">Media Server Type</label>
+                                    <CustomSelect
+                                        id="mediaServerType"
+                                        value={mediaServerType}
+                                        onChange={(val) => setMediaServerType(val === 'jellyfin' ? 'jellyfin' : 'plex')}
+                                        options={[
+                                            { label: 'Plex', value: 'plex' },
+                                            { label: 'Jellyfin', value: 'jellyfin' }
+                                        ]}
+                                    />
+                                    <div className="mt-2">
+                                        <SettingHint>
+                                            Choose the media server used for portal authentication and server-specific integrations.
+                                        </SettingHint>
+                                    </div>
+                                </div>
+                                {mediaServerType === 'jellyfin' && (
+                                    <div className="mb-6 p-4 rounded-lg border border-border bg-background/40">
+                                        <h4 className="font-bold text-text mb-3">Jellyfin Connection</h4>
+                                        <div className="mb-4">
+                                            <label htmlFor="jellyfinUrl">Jellyfin URL</label>
+                                            <input className="w-full p-3 rounded-lg border border-border bg-background text-text outline-none focus:border-plex focus:ring-1 focus:ring-plex transition-all" id="jellyfinUrl" type="url" value={jellyfinUrl} onChange={(e) => setJellyfinUrl(e.target.value)} placeholder="http://192.168.1.6:8096" />
+                                        </div>
+                                        <div className="mb-4">
+                                            <label htmlFor="jellyfinApiKey">Jellyfin API Key</label>
+                                            <input className="w-full p-3 rounded-lg border border-border bg-background text-text outline-none focus:border-plex focus:ring-1 focus:ring-plex transition-all" id="jellyfinApiKey" type="password" value={jellyfinApiKey} onChange={(e) => setJellyfinApiKey(e.target.value)} placeholder="API key from Jellyfin dashboard" />
+                                        </div>
+                                        <IntegrationTestButton
+                                            type="jellyfin"
+                                            payload={{ jellyfinUrl, jellyfinApiKey }}
+                                            disabled={!hasIntegrationCredentials(jellyfinUrl, jellyfinApiKey, initialSettings.jellyfinUrl, initialSettings.jellyfinApiKey)}
+                                            onMessage={(msg, ok) => addToast(msg, ok ? 'success' : 'error')}
+                                        />
+                                    </div>
+                                )}
+                                {mediaServerType === 'plex' && (
+                                    <>
+                                <h4 className="text-lg font-bold text-text mb-4">Plex Connection</h4>
                                 <div className="mb-4">
                                     <label htmlFor="plexToken">Plex Token</label>
                                     <input className="w-full p-3 rounded-lg border border-border bg-background text-text outline-none focus:border-plex focus:ring-1 focus:ring-plex transition-all" id="plexToken" type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder="Enter your X-Plex-Token" />
@@ -1041,6 +1190,8 @@ export const SettingsDashboard: React.FC = () => {
                                             })}
                                         </div>
                                     </div>
+                                )}
+                                    </>
                                 )}
 
                                 <div className="mb-4 mt-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3 py-4 border-b border-border/40">
@@ -1207,7 +1358,7 @@ export const SettingsDashboard: React.FC = () => {
                             <h3 className="text-xl font-bold text-plex mb-4 border-b border-border pb-2">Automated User Cleanup</h3>
                             <div className="mb-6 bg-yellow-500/10 border border-yellow-500/20 p-4 rounded-lg">
                                 <p className="text-sm text-yellow-500 font-bold mb-1">Warning</p>
-                                <p className="text-xs text-muted">When enabled, the server will automatically revoke Plex access for users who have not watched anything for the specified number of days. You can exempt specific users from this rule by editing them in the Users table.</p>
+                                <p className="text-xs text-muted">When enabled, the server will automatically revoke portal access for users who have not watched anything for the specified number of days. You can exempt specific users from this rule by editing them in the Users table.</p>
                             </div>
 
                             <div className="mb-6 flex items-center justify-between py-4 border-b border-border/40">
@@ -1243,7 +1394,7 @@ export const SettingsDashboard: React.FC = () => {
                     )}
                     {activeTab === 'mediastack' && (
                         <div className="mb-8 animate-fade-in">
-                            <h3 className="text-xl font-bold text-plex mb-4 border-b border-border pb-2">Sonarr Integration</h3>
+                            <IntegrationHeading app="sonarr" title="Sonarr Integration" subtitle="TV series automation" />
                             <div className="mb-4">
                                 <label htmlFor="sonarrUrl">Sonarr URL</label>
                                 <input className="w-full p-3 rounded-lg border border-border bg-background text-text outline-none focus:border-plex focus:ring-1 focus:ring-plex transition-all" id="sonarrUrl" type="text" value={sonarrUrl} onChange={(e) => setSonarrUrl(e.target.value)} placeholder="http://localhost:8989" />
@@ -1263,7 +1414,7 @@ export const SettingsDashboard: React.FC = () => {
                                 onMessage={(msg, ok) => addToast(msg, ok ? 'success' : 'error')}
                             />
 
-                            <h3 className="text-xl font-bold text-plex mb-4 border-b border-border pb-2 mt-8">Radarr Integration</h3>
+                            <IntegrationHeading app="radarr" title="Radarr Integration" subtitle="Movie automation" className="mt-8" />
                             <div className="mb-4">
                                 <label htmlFor="radarrUrl">Radarr URL</label>
                                 <input className="w-full p-3 rounded-lg border border-border bg-background text-text outline-none focus:border-plex focus:ring-1 focus:ring-plex transition-all" id="radarrUrl" type="text" value={radarrUrl} onChange={(e) => setRadarrUrl(e.target.value)} placeholder="http://localhost:7878" />
@@ -1282,7 +1433,7 @@ export const SettingsDashboard: React.FC = () => {
                                 className="mb-6"
                                 onMessage={(msg, ok) => addToast(msg, ok ? 'success' : 'error')}
                             />
-                            <h3 className="text-xl font-bold text-plex mb-4 border-b border-border pb-2 mt-8">Tautulli Integration (Optional)</h3>
+                            <IntegrationHeading app="tautulli" title="Tautulli Integration" subtitle="Plex activity and analytics" className="mt-8" />
                             <div className="mb-4">
                                 <label htmlFor="tautulliUrl">Tautulli URL</label>
                                 <input className="w-full p-3 rounded-lg border border-border bg-background text-text outline-none focus:border-plex focus:ring-1 focus:ring-plex transition-all" id="tautulliUrl" type="text" value={tautulliUrl} onChange={(e) => setTautulliUrl(e.target.value)} placeholder="http://localhost:8181" />
@@ -1299,7 +1450,32 @@ export const SettingsDashboard: React.FC = () => {
                                 onMessage={(msg, ok) => addToast(msg, ok ? 'success' : 'error')}
                             />
 
-                            <h3 className="text-xl font-bold text-plex mb-4 border-b border-border pb-2 mt-8">Request App Integration</h3>
+                            <IntegrationHeading app="jellystat" title="Jellystat Integration" subtitle="Jellyfin activity and analytics" className="mt-8" />
+                            <div className="mb-4">
+                                <label htmlFor="jellystatUrl">Jellystat URL</label>
+                                <input className="w-full p-3 rounded-lg border border-border bg-background text-text outline-none focus:border-plex focus:ring-1 focus:ring-plex transition-all" id="jellystatUrl" type="text" value={jellystatUrl} onChange={(e) => setJellystatUrl(e.target.value)} placeholder="http://localhost:3000" />
+                                <div className="mt-2">
+                                    <SettingHint>The URL to your Jellystat instance. Jellystat is the Jellyfin analytics companion, similar to Tautulli for Plex.</SettingHint>
+                                </div>
+                            </div>
+                            <div className="mb-8">
+                                <label htmlFor="jellystatApiKey">Jellystat API Key</label>
+                                <input className="w-full p-3 rounded-lg border border-border bg-background text-text outline-none focus:border-plex focus:ring-1 focus:ring-plex transition-all" id="jellystatApiKey" type="password" value={jellystatApiKey} onChange={(e) => setJellystatApiKey(e.target.value)} placeholder="API key from Jellystat Settings" />
+                            </div>
+                            <IntegrationTestButton
+                                type="jellystat"
+                                payload={{ jellystatUrl, jellystatApiKey }}
+                                disabled={!hasIntegrationCredentials(jellystatUrl, jellystatApiKey, initialSettings.jellystatUrl, initialSettings.jellystatApiKey)}
+                                className="mb-6"
+                                onMessage={(msg, ok) => addToast(msg, ok ? 'success' : 'error')}
+                            />
+
+                            <IntegrationHeading
+                                app={requestAppType === 'none' ? 'seerr' : requestAppType}
+                                title="Request App Integration"
+                                subtitle="Seerr, Jellyseerr, or Ombi for media requests"
+                                className="mt-8"
+                            />
                             <div className="mb-4">
                                 <label htmlFor="requestAppType">Request App Type</label>
                                 <CustomSelect
@@ -1308,7 +1484,7 @@ export const SettingsDashboard: React.FC = () => {
                                     onChange={(val) => setRequestAppType(val)}
                                     options={[
                                         { label: 'Disabled', value: 'none' },
-                                        { label: 'Overseerr', value: 'overseerr' },
+                                        { label: 'Seerr', value: 'seerr' },
                                         { label: 'Jellyseerr', value: 'jellyseerr' },
                                         { label: 'Ombi', value: 'ombi' }
                                     ]}
@@ -1431,10 +1607,56 @@ export const SettingsDashboard: React.FC = () => {
                         <div className="mb-8 animate-fade-in">
                             <h3 className="text-xl font-bold text-plex mb-4 border-b border-border pb-2">Branding & UI</h3>
                             <div className="mb-4">
+                                <label>Theme</label>
+                                <CustomSelect
+                                    value={brandTheme}
+                                    onChange={applyBrandTheme}
+                                    options={BRAND_THEME_OPTIONS}
+                                />
+                            </div>
+                            {mediaServerType === 'jellyfin' && (
+                                <div className="mb-4 rounded-lg border border-plex/30 bg-plex/10 p-4">
+                                    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                                        <div className="flex items-center gap-3 min-w-0">
+                                            <span className="w-11 h-11 rounded-lg bg-background border border-plex/30 flex items-center justify-center overflow-hidden flex-shrink-0">
+                                                <img src={JELLYFIN_BRAND_LOGO_URL} alt="" className="w-8 h-8 object-contain" />
+                                            </span>
+                                            <div className="min-w-0">
+                                                <h4 className="font-bold text-text">Jellyfin branding</h4>
+                                                <p className="text-xs text-muted mt-1">Use the Jellyfin server icon and splash background across the portal.</p>
+                                            </div>
+                                        </div>
+                                        <button
+                                            type="button"
+                                            onClick={applyJellyfinBranding}
+                                            className="px-4 py-2 bg-plex hover:bg-plex-hover text-background rounded-md font-bold transition-colors whitespace-nowrap"
+                                        >
+                                            Use Jellyfin icon & splash
+                                        </button>
+                                    </div>
+                                </div>
+                            )}
+                            <div className="mb-4">
                                 <label>Primary Accent Color</label>
                                 <div className="flex gap-4">
-                                    <input type="color" className="w-16 h-12 p-1 rounded-lg border border-border cursor-pointer bg-background" value={primaryColor} onChange={e => setPrimaryColor(e.target.value)} />
-                                    <input type="text" className="flex-1 p-3 rounded-lg border border-border bg-background text-text outline-none focus:border-plex transition-all uppercase font-mono" value={primaryColor} onChange={e => setPrimaryColor(e.target.value)} />
+                                    <input
+                                        type="color"
+                                        className="w-16 h-12 p-1 rounded-lg border border-border cursor-pointer bg-background"
+                                        value={primaryColor}
+                                        onChange={e => {
+                                            setBrandTheme('custom');
+                                            setPrimaryColor(e.target.value);
+                                        }}
+                                    />
+                                    <input
+                                        type="text"
+                                        className="flex-1 p-3 rounded-lg border border-border bg-background text-text outline-none focus:border-plex transition-all uppercase font-mono"
+                                        value={primaryColor}
+                                        onChange={e => {
+                                            setBrandTheme('custom');
+                                            setPrimaryColor(e.target.value);
+                                        }}
+                                    />
                                 </div>
                             </div>
                             <div className="mb-4">
@@ -1446,6 +1668,49 @@ export const SettingsDashboard: React.FC = () => {
                                 </div>
                                 <div className="mt-2">
                                     <SettingHint>Provide a URL or upload a file. (Max 5MB)</SettingHint>
+                                </div>
+                            </div>
+
+                            <div className="mb-4">
+                                <label>Splash Background Image</label>
+                                <input
+                                    type="url"
+                                    className="w-full p-3 rounded-lg border border-border bg-background text-text outline-none focus:border-plex transition-all"
+                                    value={backgroundImageUrl}
+                                    onChange={e => setBackgroundImageUrl(e.target.value)}
+                                    placeholder="https://example.com/background.png"
+                                />
+                                <div className="mt-2">
+                                    <SettingHint>Shown as a subtle splash image on the login screen and portal background.</SettingHint>
+                                </div>
+                            </div>
+
+                            <div className="mb-6 rounded-lg border border-border overflow-hidden bg-background/70">
+                                <div
+                                    className="relative min-h-[220px] flex items-center justify-center p-6 bg-card"
+                                    style={backgroundImageUrl ? {
+                                        backgroundImage: `linear-gradient(rgba(10,15,20,0.42), rgba(10,15,20,0.56)), url("${resolvePortalAssetUrl(backgroundImageUrl).replace(/"/g, '%22')}")`,
+                                        backgroundRepeat: 'no-repeat',
+                                        backgroundPosition: 'center',
+                                        backgroundSize: 'cover',
+                                    } : undefined}
+                                >
+                                    <div className="text-center">
+                                        {customLogoUrl ? (
+                                            <img
+                                                src={resolvePortalAssetUrl(customLogoUrl)}
+                                                alt="Server icon preview"
+                                                className="max-w-28 max-h-24 object-contain mx-auto mb-4 drop-shadow-[0_0_24px_rgba(0,0,0,0.75)]"
+                                                onError={(e) => { e.currentTarget.style.display = 'none'; }}
+                                            />
+                                        ) : (
+                                            <div className="w-24 h-24 rounded-full border-2 border-plex/50 bg-background/80 mx-auto mb-4 p-3 shadow-[0_0_36px_rgba(0,164,220,0.28)]">
+                                                <span className="w-full h-full flex items-center justify-center text-3xl font-black text-plex">S</span>
+                                            </div>
+                                        )}
+                                        <p className="text-sm font-bold text-text">Portal splash preview</p>
+                                        <p className="text-xs text-muted mt-1">This is the server icon and background users will see.</p>
+                                    </div>
                                 </div>
                             </div>
 
@@ -1697,15 +1962,24 @@ export const SettingsDashboard: React.FC = () => {
                                         <div><strong>Uptime:</strong> {diagnostics?.app?.uptimeSeconds || 0}s</div>
                                         <div><strong>Node:</strong> {diagnostics?.app?.nodeVersion || 'n/a'}</div>
                                         <div><strong>Memory:</strong> {diagnostics?.app?.memoryRssMB || 0} MB</div>
-                                        <div className="flex items-center justify-between gap-2"><strong>Plex</strong>{renderConfigPill(!!diagnostics?.integrations?.plexConfigured)}</div>
+                                        <div className="flex items-center justify-between gap-2">
+                                            <strong>Media Player ({mediaServerType === 'jellyfin' ? 'Jellyfin' : 'Plex'})</strong>
+                                            {renderConfigPill(mediaServerType === 'jellyfin' ? !!diagnostics?.integrations?.jellyfinConfigured : !!diagnostics?.integrations?.plexConfigured)}
+                                        </div>
                                         <div className="flex items-center justify-between gap-2"><strong>SMTP</strong>{renderOptionalIntegrationPill(!!diagnostics?.integrations?.smtpConfigured)}</div>
                                         <div className="flex items-center justify-between gap-2"><strong>Sonarr</strong>{renderConfigPill(!!diagnostics?.integrations?.sonarrConfigured)}</div>
                                         <div className="flex items-center justify-between gap-2"><strong>Radarr</strong>{renderConfigPill(!!diagnostics?.integrations?.radarrConfigured)}</div>
-                                        <div className="flex items-center justify-between gap-2"><strong>Tautulli</strong>{renderConfigPill(!!diagnostics?.integrations?.tautulliConfigured)}</div>
+                                        {mediaServerType === 'jellyfin' ? (
+                                            <div className="flex items-center justify-between gap-2"><strong>Jellystat</strong>{renderConfigPill(!!diagnostics?.integrations?.jellystatConfigured)}</div>
+                                        ) : (
+                                            <div className="flex items-center justify-between gap-2"><strong>Tautulli</strong>{renderConfigPill(!!diagnostics?.integrations?.tautulliConfigured)}</div>
+                                        )}
                                         <div className="flex items-center justify-between gap-2"><strong>Request App</strong>{renderOptionalPill(!!diagnostics?.integrations?.requestAppEnabled, !!diagnostics?.integrations?.requestAppConfigured)}</div>
                                         <div className="flex items-center justify-between gap-2"><strong>Analytics Cache</strong>{renderConfigPill(!!diagnostics?.caches?.analytics?.exists)}</div>
                                         <div className="flex items-center justify-between gap-2"><strong>Trending Cache</strong>{renderConfigPill(!!diagnostics?.caches?.trending?.exists)}</div>
-                                        <div className="flex items-center justify-between gap-2"><strong>Plex Stats Cache</strong>{renderConfigPill(!!diagnostics?.caches?.plexStats?.exists)}</div>
+                                        {mediaServerType !== 'jellyfin' && (
+                                            <div className="flex items-center justify-between gap-2"><strong>Plex Stats Cache</strong>{renderConfigPill(!!diagnostics?.caches?.plexStats?.exists)}</div>
+                                        )}
                                         <div className="flex items-center justify-between gap-2"><strong>Users File</strong>{renderConfigPill(!!diagnostics?.files?.users?.exists)}</div>
                                         <div className="flex items-center justify-between gap-2"><strong>Config File</strong>{renderConfigPill(!!diagnostics?.files?.config?.exists)}</div>
                                         <div className="flex items-center justify-between gap-2"><strong>Auto Backup</strong>{renderConfigPill(!!diagnostics?.backup?.enabled)}</div>

--- a/client/setup/SetupWizard.tsx
+++ b/client/setup/SetupWizard.tsx
@@ -7,11 +7,12 @@ import { getPublicOrigin, logoUrl, portalUrl, stripBasePath } from '../shared/ba
 import { IntegrationTestButton } from '../shared/IntegrationTestButton';
 import { CustomSelect } from '../shared/ui';
 import { AuthPageBackground, themeClasses } from '../shared/theme';
+import { accentHoverRgb, hexToRgb } from '../shared/format';
 import type { PlexServer } from '../shared/types';
 
 const STEPS = [
     { id: 'welcome', label: 'Welcome', icon: Sparkles, hint: 'Overview & what to expect' },
-    { id: 'plex', label: 'Plex', icon: Server, hint: 'Connect your media server' },
+    { id: 'plex', label: 'Media Server', icon: Server, hint: 'Choose Plex or Jellyfin' },
     { id: 'branding', label: 'Branding', icon: Palette, hint: 'Colors, logo & domain' },
     { id: 'email', label: 'Email', icon: Mail, hint: 'SMTP alerts & newsletters' },
     { id: 'integrations', label: 'Integrations', icon: Layers, hint: 'Sonarr, Radarr & more' },
@@ -21,7 +22,7 @@ const STEPS = [
 type StepId = (typeof STEPS)[number]['id'];
 
 const WELCOME_FEATURES = [
-    { icon: Server, title: 'Plex OAuth', desc: 'Secure sign-in as server owner' },
+    { icon: Server, title: 'Plex or Jellyfin', desc: 'Choose and test your media server' },
     { icon: Palette, title: 'Your Brand', desc: 'Custom colors, logo & domain' },
     { icon: Mail, title: 'Email Alerts', desc: 'Expiry reminders & newsletters' },
     { icon: Layers, title: 'Media Stack', desc: 'Sonarr, Radarr, Tautulli & requests' },
@@ -31,10 +32,54 @@ const SETUP_PLEX_STORAGE_KEY = 'setupWizardPlex';
 
 const REQUEST_APP_OPTIONS = [
     { label: 'Disabled', value: 'none' },
-    { label: 'Overseerr', value: 'overseerr' },
+    { label: 'Seerr', value: 'seerr' },
     { label: 'Jellyseerr', value: 'jellyseerr' },
     { label: 'Ombi', value: 'ombi' },
 ];
+
+const SELFHST_ICON_BASE = 'https://cdn.jsdelivr.net/gh/selfhst/icons/svg';
+const APP_ICONS: Record<string, string> = {
+    sonarr: `${SELFHST_ICON_BASE}/sonarr.svg`,
+    radarr: `${SELFHST_ICON_BASE}/radarr.svg`,
+    tautulli: `${SELFHST_ICON_BASE}/tautulli.svg`,
+    seerr: `${SELFHST_ICON_BASE}/seerr.svg`,
+    overseerr: `${SELFHST_ICON_BASE}/seerr.svg`,
+    jellyseerr: `${SELFHST_ICON_BASE}/jellyseerr.svg`,
+    ombi: `${SELFHST_ICON_BASE}/ombi.svg`,
+    jellystat: 'https://cdn.jsdelivr.net/gh/selfhst/icons@main/png/jellystat.png',
+};
+
+const ProgramIcon: React.FC<{ app: string; label: string }> = ({ app, label }) => (
+    <span className="w-8 h-8 rounded-lg bg-white/5 border border-white/10 flex items-center justify-center overflow-hidden flex-shrink-0">
+        {APP_ICONS[app] ? (
+            <img
+                src={APP_ICONS[app]}
+                alt=""
+                className="w-5 h-5 object-contain"
+                onError={(e) => { e.currentTarget.style.display = 'none'; }}
+            />
+        ) : (
+            <span className="text-[10px] font-black text-plex">{label.slice(0, 2).toUpperCase()}</span>
+        )}
+        <span className="sr-only">{label}</span>
+    </span>
+);
+
+const MEDIA_SERVER_OPTIONS = [
+    { label: 'Plex', value: 'plex' },
+    { label: 'Jellyfin', value: 'jellyfin' },
+];
+
+const BRAND_THEME_OPTIONS = [
+    { label: 'Plex', value: 'plex' },
+    { label: 'Jellyfin', value: 'jellyfin' },
+    { label: 'Custom', value: 'custom' },
+];
+
+const BRAND_THEME_COLORS: Record<string, string> = {
+    plex: '#F7C600',
+    jellyfin: '#00A4DC',
+};
 
 const readStoredSetupPlex = () => {
     try {
@@ -42,12 +87,16 @@ const readStoredSetupPlex = () => {
         if (!raw) return null;
         return JSON.parse(raw) as {
             token?: string;
+            mediaServerType?: string;
             servers?: PlexServer[];
             serverIdentifier?: string;
             plexServerUrl?: string;
+            jellyfinUrl?: string;
+            jellyfinApiKey?: string;
             username?: string;
             step?: StepId;
             publicDomain?: string;
+            brandTheme?: string;
             primaryColor?: string;
             customLogoUrl?: string;
             smtpHost?: string;
@@ -62,6 +111,8 @@ const readStoredSetupPlex = () => {
             radarrApiKey?: string;
             tautulliUrl?: string;
             tautulliApiKey?: string;
+            jellystatUrl?: string;
+            jellystatApiKey?: string;
             requestAppType?: string;
             requestAppUrl?: string;
             requestAppApiKey?: string;
@@ -85,14 +136,18 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
     const [isLoading, setIsLoading] = useState(false);
 
     const [token, setToken] = useState(storedPlex?.token || '');
+    const [mediaServerType, setMediaServerType] = useState(storedPlex?.mediaServerType || 'plex');
     const [serverIdentifier, setServerIdentifier] = useState(storedPlex?.serverIdentifier || '');
     const [plexServerUrl, setPlexServerUrl] = useState(storedPlex?.plexServerUrl || '');
+    const [jellyfinUrl, setJellyfinUrl] = useState(storedPlex?.jellyfinUrl || '');
+    const [jellyfinApiKey, setJellyfinApiKey] = useState(storedPlex?.jellyfinApiKey || '');
     const [servers, setServers] = useState<PlexServer[]>(storedPlex?.servers || []);
     const [plexUsername, setPlexUsername] = useState(storedPlex?.username || '');
     const [showManualToken, setShowManualToken] = useState(false);
 
     const [publicDomain, setPublicDomain] = useState(storedPlex?.publicDomain ?? (typeof window !== 'undefined' ? getPublicOrigin() : ''));
-    const [primaryColor, setPrimaryColor] = useState(storedPlex?.primaryColor ?? '#E5A00D');
+    const [brandTheme, setBrandTheme] = useState(storedPlex?.brandTheme ?? 'plex');
+    const [primaryColor, setPrimaryColor] = useState(storedPlex?.primaryColor ?? BRAND_THEME_COLORS.plex);
     const [customLogoUrl, setCustomLogoUrl] = useState(storedPlex?.customLogoUrl ?? '');
 
     const [smtpHost, setSmtpHost] = useState(storedPlex?.smtpHost ?? '');
@@ -109,22 +164,55 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
     const [radarrApiKey, setRadarrApiKey] = useState(storedPlex?.radarrApiKey ?? '');
     const [tautulliUrl, setTautulliUrl] = useState(storedPlex?.tautulliUrl ?? '');
     const [tautulliApiKey, setTautulliApiKey] = useState(storedPlex?.tautulliApiKey ?? '');
-    const [requestAppType, setRequestAppType] = useState(storedPlex?.requestAppType ?? 'none');
+    const [jellystatUrl, setJellystatUrl] = useState(storedPlex?.jellystatUrl ?? '');
+    const [jellystatApiKey, setJellystatApiKey] = useState(storedPlex?.jellystatApiKey ?? '');
+    const [requestAppType, setRequestAppType] = useState(storedPlex?.requestAppType === 'overseerr' ? 'seerr' : (storedPlex?.requestAppType ?? 'none'));
     const [requestAppUrl, setRequestAppUrl] = useState(storedPlex?.requestAppUrl ?? '');
     const [requestAppApiKey, setRequestAppApiKey] = useState(storedPlex?.requestAppApiKey ?? '');
+    const [integrationTab, setIntegrationTab] = useState<'arr' | 'requests' | 'analytics'>('arr');
 
     const stepIndex = STEPS.findIndex((s) => s.id === step);
-    const canGoNext = step !== 'plex' || (token && serverIdentifier);
+    const canGoNext = step !== 'plex'
+        || (mediaServerType === 'jellyfin'
+            ? Boolean(jellyfinUrl && jellyfinApiKey)
+            : Boolean(token && serverIdentifier));
+
+    const applyBrandTheme = (theme: string) => {
+        setBrandTheme(theme);
+        if (theme === 'plex' || theme === 'jellyfin') {
+            setPrimaryColor(BRAND_THEME_COLORS[theme]);
+        }
+    };
+
+    const applyMediaServerType = (type: string) => {
+        const nextType = type === 'jellyfin' ? 'jellyfin' : 'plex';
+        setMediaServerType(nextType);
+        if (brandTheme === 'plex' || brandTheme === 'jellyfin') {
+            applyBrandTheme(nextType);
+        }
+        if (requestAppType === 'none' || requestAppType === 'seerr' || requestAppType === 'overseerr' || requestAppType === 'jellyseerr') {
+            setRequestAppType(nextType === 'jellyfin' ? 'jellyseerr' : 'seerr');
+        }
+    };
+
+    useEffect(() => {
+        document.documentElement.style.setProperty('--color-plex', hexToRgb(primaryColor));
+        document.documentElement.style.setProperty('--color-plex-hover', accentHoverRgb(primaryColor));
+    }, [primaryColor]);
 
     const persistSetupPlex = (patch: Partial<ReturnType<typeof readStoredSetupPlex>>) => {
         const next = {
             token,
+            mediaServerType,
             servers,
             serverIdentifier,
             plexServerUrl,
+            jellyfinUrl,
+            jellyfinApiKey,
             username: plexUsername,
             step,
             publicDomain,
+            brandTheme,
             primaryColor,
             customLogoUrl,
             smtpHost,
@@ -139,6 +227,8 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
             radarrApiKey,
             tautulliUrl,
             tautulliApiKey,
+            jellystatUrl,
+            jellystatApiKey,
             requestAppType,
             requestAppUrl,
             requestAppApiKey,
@@ -257,8 +347,11 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
                 method: 'POST',
                 body: JSON.stringify({
                     token: token.trim(),
+                    mediaServerType,
                     serverIdentifier: serverIdentifier.trim(),
                     plexServerUrl: plexServerUrl || undefined,
+                    jellyfinUrl,
+                    jellyfinApiKey,
                     publicDomain,
                     primaryColor,
                     customLogoUrl,
@@ -274,6 +367,8 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
                     radarrApiKey,
                     tautulliUrl,
                     tautulliApiKey,
+                    jellystatUrl,
+                    jellystatApiKey,
                     requestAppType,
                     requestAppUrl,
                     requestAppApiKey,
@@ -357,7 +452,7 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
                             </div>
                             <div className="h-2 bg-white/5 rounded-full overflow-hidden border border-white/5">
                                 <div
-                                    className="h-full bg-gradient-to-r from-plex via-amber-400 to-orange-500 rounded-full transition-all duration-500 ease-out shadow-[0_0_12px_rgba(229,160,13,0.5)]"
+                                    className="h-full bg-gradient-to-r from-plex via-plex-hover to-plex rounded-full transition-all duration-500 ease-out shadow-plex/20 shadow-lg"
                                     style={{ width: `${progressPct}%` }}
                                 />
                             </div>
@@ -371,7 +466,7 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
                         <div className="lg:hidden border-b border-white/10 bg-black/20 px-4 py-4 overflow-x-auto">
                             <div className="flex items-center gap-2 min-w-max">{renderStepNav(true)}</div>
                             <div className="mt-3 h-1.5 bg-white/5 rounded-full overflow-hidden">
-                                <div className="h-full bg-gradient-to-r from-plex to-amber-400 transition-all duration-500" style={{ width: `${progressPct}%` }} />
+                                <div className="h-full bg-gradient-to-r from-plex to-plex-hover transition-all duration-500" style={{ width: `${progressPct}%` }} />
                             </div>
                         </div>
 
@@ -392,7 +487,7 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
                                         Welcome to your<br className="hidden sm:block" /> media portal
                                     </h2>
                                     <p className="text-muted text-base sm:text-lg leading-relaxed mb-8 max-w-xl">
-                                        A guided setup to connect Plex, brand your portal, and optionally wire up email and your media stack. Takes about five minutes.
+                                        A guided setup to connect Plex or Jellyfin, brand your portal, and optionally wire up email and your media stack. Takes about five minutes.
                                     </p>
                                     <div className="grid sm:grid-cols-2 gap-3 mb-2">
                                         {WELCOME_FEATURES.map(({ icon: Icon, title, desc }) => (
@@ -414,11 +509,31 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
                         <div className="flex flex-col gap-6 max-w-2xl">
                             <div>
                                 <p className={labelClass + ' mb-2'}>Step {stepIndex + 1}</p>
-                                <h2 className="text-2xl sm:text-3xl font-black text-text tracking-tight mb-2">Plex Connection</h2>
-                                <p className="text-muted text-sm sm:text-base leading-relaxed">Sign in with your Plex account as the <strong className="text-text font-semibold">server owner</strong> to connect your library.</p>
+                                <h2 className="text-2xl sm:text-3xl font-black text-text tracking-tight mb-2">Media Server Connection</h2>
+                                <p className="text-muted text-sm sm:text-base leading-relaxed">Choose and connect the media server that will back this portal.</p>
                             </div>
 
-                            {!token ? (
+                            <div className={`${sectionCardClass} flex flex-col gap-4`}>
+                                <div className="flex flex-col gap-2.5">
+                                    <label className={labelClass}>Media Server Type</label>
+                                    <CustomSelect value={mediaServerType} onChange={applyMediaServerType} options={MEDIA_SERVER_OPTIONS} />
+                                </div>
+                                {mediaServerType === 'jellyfin' && (
+                                    <>
+                                        <div className="flex flex-col gap-2.5">
+                                            <label className={labelClass}>Jellyfin URL</label>
+                                            <input type="url" className={inputClass} value={jellyfinUrl} onChange={(e) => setJellyfinUrl(e.target.value)} placeholder="http://192.168.1.6:8096" />
+                                        </div>
+                                        <div className="flex flex-col gap-2.5">
+                                            <label className={labelClass}>Jellyfin API Key</label>
+                                            <input type="password" className={inputClass} value={jellyfinApiKey} onChange={(e) => setJellyfinApiKey(e.target.value)} placeholder="API key from Jellyfin dashboard" />
+                                        </div>
+                                        <IntegrationTestButton type="jellyfin" payload={{ jellyfinUrl, jellyfinApiKey }} disabled={!jellyfinUrl || !jellyfinApiKey} />
+                                    </>
+                                )}
+                            </div>
+
+                            {mediaServerType === 'plex' && (!token ? (
                                 <div className={`${sectionCardClass} flex flex-col gap-4`}>
                                     <button
                                         type="button"
@@ -454,9 +569,9 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
                                         Sign out
                                     </button>
                                 </div>
-                            )}
+                            ))}
 
-                            {servers.length > 0 ? (
+                            {mediaServerType === 'plex' && (servers.length > 0 ? (
                                 <div className="flex flex-col gap-2.5">
                                     <label className={labelClass}>Select Server</label>
                                     <CustomSelect value={serverIdentifier} onChange={setServerIdentifier} options={servers.map((s) => ({ label: `${s.name} (${s.identifier})`, value: s.identifier }))} />
@@ -473,9 +588,9 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
                                         <p>2) Copy <code className="bg-background px-1.5 py-0.5 rounded">machineIdentifier</code> from the response.</p>
                                     </div>
                                 </div>
-                            ) : null}
+                            ) : null)}
 
-                            <div className="flex flex-col gap-2.5">
+                            {mediaServerType === 'plex' && <div className="flex flex-col gap-2.5">
                                 <label className={labelClass}>
                                     Direct Plex URL <span className="text-muted/70 font-normal normal-case tracking-normal">(required in Docker)</span>
                                 </label>
@@ -487,15 +602,15 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
                                     placeholder="http://192.168.1.6:32400"
                                 />
                                 <p className="text-xs text-muted leading-relaxed">Your Plex server&apos;s LAN address. Required when Plex.tv discovery fails from inside the container.</p>
-                            </div>
+                            </div>}
 
-                            <IntegrationTestButton
+                            {mediaServerType === 'plex' && <IntegrationTestButton
                                 type="plex"
                                 payload={{ token, serverIdentifier, plexServerUrl: plexServerUrl || undefined }}
                                 disabled={!token || !serverIdentifier}
-                            />
+                            />}
 
-                            <div className="border-t border-white/10 pt-5">
+                            {mediaServerType === 'plex' && <div className="border-t border-white/10 pt-5">
                                 <button
                                     type="button"
                                     onClick={() => setShowManualToken(!showManualToken)}
@@ -519,7 +634,7 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
                                         </div>
                                     </div>
                                 )}
-                            </div>
+                            </div>}
                         </div>
                     )}
 
@@ -536,10 +651,31 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
                                     <input type="text" className={inputClass} value={publicDomain} onChange={(e) => setPublicDomain(e.target.value)} placeholder="https://portal.yourdomain.com" />
                                 </div>
                                 <div className="flex flex-col gap-2.5">
+                                    <label className={labelClass}>Theme</label>
+                                    <CustomSelect value={brandTheme} onChange={applyBrandTheme} options={BRAND_THEME_OPTIONS} />
+                                </div>
+                                <div className="flex flex-col gap-2.5">
                                     <label className={labelClass}>Primary Color</label>
                                     <div className="flex gap-3 items-center">
-                                        <input type="color" value={primaryColor} onChange={(e) => setPrimaryColor(e.target.value)} className="w-14 h-14 rounded-xl border border-white/10 cursor-pointer bg-transparent flex-shrink-0" />
-                                        <input type="text" className={inputClass} value={primaryColor} onChange={(e) => setPrimaryColor(e.target.value)} placeholder="#E5A00D" />
+                                        <input
+                                            type="color"
+                                            value={primaryColor}
+                                            onChange={(e) => {
+                                                setBrandTheme('custom');
+                                                setPrimaryColor(e.target.value);
+                                            }}
+                                            className="w-14 h-14 rounded-xl border border-white/10 cursor-pointer bg-transparent flex-shrink-0"
+                                        />
+                                        <input
+                                            type="text"
+                                            className={inputClass}
+                                            value={primaryColor}
+                                            onChange={(e) => {
+                                                setBrandTheme('custom');
+                                                setPrimaryColor(e.target.value);
+                                            }}
+                                            placeholder="#F7C600"
+                                        />
                                     </div>
                                 </div>
                                 <div className="flex flex-col gap-2.5">
@@ -601,41 +737,102 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
                     )}
 
                     {step === 'integrations' && (
-                        <div className="flex flex-col gap-5 max-w-2xl">
+                        <div className="flex flex-col gap-5 max-w-4xl">
                             <div>
                                 <p className={labelClass + ' mb-2'}>Step {stepIndex + 1}</p>
                                 <h2 className="text-2xl sm:text-3xl font-black text-text tracking-tight mb-2">Media Stack</h2>
-                                <p className="text-muted text-sm sm:text-base">All optional — powers analytics, maintenance rules, and media stack pages.</p>
+                                <p className="text-muted text-sm sm:text-base">All optional. Connect the apps that manage requests, downloads, activity, and maintenance.</p>
                             </div>
-                            {[
-                                { label: 'Sonarr', url: sonarrUrl, setUrl: setSonarrUrl, key: sonarrApiKey, setKey: setSonarrApiKey, type: 'sonarr' as const, placeholder: 'http://localhost:8989' },
-                                { label: 'Radarr', url: radarrUrl, setUrl: setRadarrUrl, key: radarrApiKey, setKey: setRadarrApiKey, type: 'radarr' as const, placeholder: 'http://localhost:7878' },
-                                { label: 'Tautulli', url: tautulliUrl, setUrl: setTautulliUrl, key: tautulliApiKey, setKey: setTautulliApiKey, type: 'tautulli' as const, placeholder: 'http://localhost:8181' },
-                            ].map(({ label, url, setUrl, key, setKey, type, placeholder }) => (
-                                <div key={type} className={`${sectionCardClass} flex flex-col gap-3.5`}>
-                                    <h3 className="font-bold text-plex text-base flex items-center gap-2">
-                                        <span className="w-2 h-2 rounded-full bg-plex shadow-[0_0_8px_rgba(229,160,13,0.6)]" />
-                                        {label}
-                                    </h3>
-                                    <input type="text" className={inputClass} value={url} onChange={(e) => setUrl(e.target.value)} placeholder={placeholder} />
-                                    <input type="password" className={inputClass} value={key} onChange={(e) => setKey(e.target.value)} placeholder="API Key" />
-                                    <IntegrationTestButton type={type} payload={{ [`${type}Url`]: url, [`${type}ApiKey`]: key }} disabled={!url || !key} />
+                            <div className="grid grid-cols-3 gap-2 rounded-xl border border-white/10 bg-background/50 p-1.5">
+                                {[
+                                    { id: 'arr' as const, label: 'Arr Apps' },
+                                    { id: 'requests' as const, label: 'Requests' },
+                                    { id: 'analytics' as const, label: mediaServerType === 'jellyfin' ? 'Jellystat' : 'Tautulli' },
+                                ].map((tab) => (
+                                    <button
+                                        key={tab.id}
+                                        type="button"
+                                        onClick={() => setIntegrationTab(tab.id)}
+                                        className={`px-3 py-2.5 rounded-lg text-xs sm:text-sm font-bold transition-all ${integrationTab === tab.id ? 'bg-plex text-background shadow-lg shadow-plex/20' : 'text-muted hover:text-text hover:bg-white/5'}`}
+                                    >
+                                        {tab.label}
+                                    </button>
+                                ))}
+                            </div>
+
+                            {integrationTab === 'arr' && (
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    {[
+                                        { label: 'Sonarr', desc: 'TV series automation', url: sonarrUrl, setUrl: setSonarrUrl, key: sonarrApiKey, setKey: setSonarrApiKey, type: 'sonarr' as const, placeholder: 'http://localhost:8989' },
+                                        { label: 'Radarr', desc: 'Movie automation', url: radarrUrl, setUrl: setRadarrUrl, key: radarrApiKey, setKey: setRadarrApiKey, type: 'radarr' as const, placeholder: 'http://localhost:7878' },
+                                    ].map(({ label, desc, url, setUrl, key, setKey, type, placeholder }) => (
+                                        <div key={type} className={`${sectionCardClass} flex flex-col gap-3.5`}>
+                                            <div className="flex items-center gap-3">
+                                                <ProgramIcon app={type} label={label} />
+                                                <div>
+                                                    <h3 className="font-bold text-text text-base leading-tight">{label}</h3>
+                                                    <p className="text-xs text-muted mt-0.5">{desc}</p>
+                                                </div>
+                                            </div>
+                                            <input type="text" className={inputClass} value={url} onChange={(e) => setUrl(e.target.value)} placeholder={placeholder} />
+                                            <input type="password" className={inputClass} value={key} onChange={(e) => setKey(e.target.value)} placeholder="API Key" />
+                                            <IntegrationTestButton type={type} payload={{ [`${type}Url`]: url, [`${type}ApiKey`]: key }} disabled={!url || !key} />
+                                        </div>
+                                    ))}
                                 </div>
-                            ))}
-                            <div className={`${sectionCardClass} flex flex-col gap-3.5`}>
-                                <h3 className="font-bold text-plex text-base flex items-center gap-2">
-                                    <span className="w-2 h-2 rounded-full bg-plex shadow-[0_0_8px_rgba(229,160,13,0.6)]" />
-                                    Request App
-                                </h3>
-                                <CustomSelect value={requestAppType} onChange={setRequestAppType} options={REQUEST_APP_OPTIONS} />
-                                {requestAppType !== 'none' && (
-                                    <>
-                                        <input type="text" className={inputClass} value={requestAppUrl} onChange={(e) => setRequestAppUrl(e.target.value)} placeholder="http://localhost:5055" />
-                                        <input type="password" className={inputClass} value={requestAppApiKey} onChange={(e) => setRequestAppApiKey(e.target.value)} placeholder="API Key" />
-                                        <IntegrationTestButton type="requestApp" payload={{ requestAppType, requestAppUrl, requestAppApiKey }} disabled={!requestAppUrl || !requestAppApiKey} />
-                                    </>
-                                )}
-                            </div>
+                            )}
+
+                            {integrationTab === 'requests' && (
+                                <div className={`${sectionCardClass} flex flex-col gap-3.5`}>
+                                    <div className="flex items-center gap-3">
+                                        <ProgramIcon app={requestAppType === 'none' ? (mediaServerType === 'jellyfin' ? 'jellyseerr' : 'seerr') : requestAppType} label="Request App" />
+                                        <div>
+                                            <h3 className="font-bold text-text text-base leading-tight">Request App</h3>
+                                            <p className="text-xs text-muted mt-0.5">Seerr, Jellyseerr, or Ombi for user requests.</p>
+                                        </div>
+                                    </div>
+                                    <CustomSelect value={requestAppType} onChange={setRequestAppType} options={REQUEST_APP_OPTIONS} />
+                                    {requestAppType !== 'none' && (
+                                        <>
+                                            <input type="text" className={inputClass} value={requestAppUrl} onChange={(e) => setRequestAppUrl(e.target.value)} placeholder="http://localhost:5055" />
+                                            <input type="password" className={inputClass} value={requestAppApiKey} onChange={(e) => setRequestAppApiKey(e.target.value)} placeholder="API Key" />
+                                            <IntegrationTestButton type="requestApp" payload={{ requestAppType, requestAppUrl, requestAppApiKey }} disabled={!requestAppUrl || !requestAppApiKey} />
+                                        </>
+                                    )}
+                                </div>
+                            )}
+
+                            {integrationTab === 'analytics' && (
+                                <div className={`${sectionCardClass} flex flex-col gap-3.5`}>
+                                    {mediaServerType === 'jellyfin' ? (
+                                        <>
+                                            <div className="flex items-center gap-3">
+                                                <ProgramIcon app="jellystat" label="Jellystat" />
+                                                <div>
+                                                    <h3 className="font-bold text-text text-base leading-tight">Jellystat</h3>
+                                                    <p className="text-xs text-muted mt-0.5">Jellyfin activity and analytics.</p>
+                                                </div>
+                                            </div>
+                                            <input type="text" className={inputClass} value={jellystatUrl} onChange={(e) => setJellystatUrl(e.target.value)} placeholder="http://localhost:3000" />
+                                            <input type="password" className={inputClass} value={jellystatApiKey} onChange={(e) => setJellystatApiKey(e.target.value)} placeholder="API Key" />
+                                            <IntegrationTestButton type="jellystat" payload={{ jellystatUrl, jellystatApiKey }} disabled={!jellystatUrl || !jellystatApiKey} />
+                                        </>
+                                    ) : (
+                                        <>
+                                            <div className="flex items-center gap-3">
+                                                <ProgramIcon app="tautulli" label="Tautulli" />
+                                                <div>
+                                                    <h3 className="font-bold text-text text-base leading-tight">Tautulli</h3>
+                                                    <p className="text-xs text-muted mt-0.5">Plex activity and analytics.</p>
+                                                </div>
+                                            </div>
+                                            <input type="text" className={inputClass} value={tautulliUrl} onChange={(e) => setTautulliUrl(e.target.value)} placeholder="http://localhost:8181" />
+                                            <input type="password" className={inputClass} value={tautulliApiKey} onChange={(e) => setTautulliApiKey(e.target.value)} placeholder="API Key" />
+                                            <IntegrationTestButton type="tautulli" payload={{ tautulliUrl, tautulliApiKey }} disabled={!tautulliUrl || !tautulliApiKey} />
+                                        </>
+                                    )}
+                                </div>
+                            )}
                         </div>
                     )}
 
@@ -647,11 +844,11 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
                             <p className={labelClass + ' mb-3'}>Step {stepIndex + 1}</p>
                             <h2 className="text-3xl sm:text-4xl font-black text-text tracking-tight mb-4">Ready to launch</h2>
                             <p className="text-muted text-base leading-relaxed mb-8">
-                                Your Plex server{sonarrUrl ? ', Sonarr' : ''}{radarrUrl ? ', Radarr' : ''}{tautulliUrl ? ', Tautulli' : ''} will be saved.
+                                Your {mediaServerType === 'jellyfin' ? 'Jellyfin' : 'Plex'} server{sonarrUrl ? ', Sonarr' : ''}{radarrUrl ? ', Radarr' : ''}{tautulliUrl ? ', Tautulli' : ''}{jellystatUrl ? ', Jellystat' : ''} will be saved.
                                 {smtpHost ? ' Email notifications enabled.' : ' You can add email later in Settings.'}
                             </p>
                             <div className={`${sectionCardClass} text-left text-sm space-y-3`}>
-                                <p className="flex justify-between gap-4 border-b border-white/5 pb-3"><span className="text-muted">Server</span> <strong className="text-text truncate">{serverIdentifier || '—'}</strong></p>
+                                <p className="flex justify-between gap-4 border-b border-white/5 pb-3"><span className="text-muted">Server</span> <strong className="text-text truncate">{mediaServerType === 'jellyfin' ? (jellyfinUrl || '—') : (serverIdentifier || '—')}</strong></p>
                                 <p className="flex justify-between gap-4 border-b border-white/5 pb-3"><span className="text-muted">Portal URL</span> <strong className="text-text truncate">{publicDomain || '—'}</strong></p>
                                 <p className="flex justify-between gap-4 items-center"><span className="text-muted">Accent</span> <span className="flex items-center gap-2"><span className="inline-block w-5 h-5 rounded-md border border-white/20 shadow-inner" style={{ backgroundColor: primaryColor }} /><strong className="text-text">{primaryColor}</strong></span></p>
                             </div>
@@ -669,7 +866,7 @@ export const SetupWizard: React.FC<{ onComplete: () => void }> = ({ onComplete }
                                 {STEPS[stepIndex].label} · {stepIndex + 1}/{STEPS.length}
                             </span>
                             {step === 'finish' ? (
-                                <button type="button" onClick={handleComplete} disabled={isLoading || !token || !serverIdentifier}
+                                <button type="button" onClick={handleComplete} disabled={isLoading || !canGoNext}
                                     className={primaryBtnClass}>
                                     {isLoading ? 'Saving…' : 'Complete Setup'} <Check className="w-4 h-4" />
                                 </button>

--- a/client/shared/IntegrationTestButton.tsx
+++ b/client/shared/IntegrationTestButton.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { RefreshCw, CheckCircle, XCircle } from 'lucide-react';
 import { apiFetch } from './api';
 
-export type IntegrationTestType = 'plex' | 'sonarr' | 'radarr' | 'tautulli' | 'requestApp';
+export type IntegrationTestType = 'plex' | 'jellyfin' | 'sonarr' | 'radarr' | 'tautulli' | 'jellystat' | 'requestApp';
 
 type Props = {
     type: IntegrationTestType;

--- a/client/shared/format.ts
+++ b/client/shared/format.ts
@@ -88,6 +88,12 @@ export const hexToRgb = (hex: string) => {
     return `${r} ${g} ${b}`;
 };
 
+export const accentHoverRgb = (hex: string) => {
+    const [r, g, b] = hexToRgb(hex).split(' ').map(Number);
+    const lift = (value: number) => Math.min(255, Math.round(value + (255 - value) * 0.18));
+    return `${lift(r)} ${lift(g)} ${lift(b)}`;
+};
+
 /** Round storage up to the nearest whole MB, GB, TB, or PB. */
 export const formatSizeCeil = (bytes: number): string => {
     const safe = Math.max(0, Number(bytes) || 0);

--- a/client/shared/theme.tsx
+++ b/client/shared/theme.tsx
@@ -2,24 +2,56 @@ import React from 'react';
 
 const GRID_TEXTURE = 'url("data:image/svg+xml,%3Csvg width=\'60\' height=\'60\' viewBox=\'0 0 60 60\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cg fill=\'none\' fill-rule=\'evenodd\'%3E%3Cg fill=\'%23ffffff\' fill-opacity=\'1\'%3E%3Cpath d=\'M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z\'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")';
 
+const backgroundImageStyle = (url?: string): React.CSSProperties | undefined => {
+    const cleanUrl = String(url || '').trim();
+    if (!cleanUrl) return undefined;
+    return {
+        backgroundImage: `url("${cleanUrl.replace(/"/g, '%22')}")`,
+    };
+};
+
 /** Full-intensity ambient background for login / setup wizard */
-export const AuthPageBackground: React.FC = () => (
+export const AuthPageBackground: React.FC<{ backgroundImageUrl?: string }> = ({ backgroundImageUrl }) => (
     <div className="pointer-events-none absolute inset-0 bg-background">
         <div className="absolute -top-32 -left-32 w-[520px] h-[520px] rounded-full bg-plex/10 blur-[120px]" />
-        <div className="absolute top-1/3 -right-24 w-[480px] h-[480px] rounded-full bg-amber-500/8 blur-[100px]" />
+        <div className="absolute top-1/3 -right-24 w-[480px] h-[480px] rounded-full bg-plex/8 blur-[100px]" />
         <div className="absolute bottom-0 left-1/4 w-[400px] h-[400px] rounded-full bg-plex/5 blur-[90px]" />
-        <div className="absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_-20%,rgba(229,160,13,0.12),transparent)]" />
+        <div
+            className="absolute inset-0"
+            style={{ backgroundImage: 'radial-gradient(ellipse 80% 50% at 50% -20%, rgb(var(--color-plex) / 0.12), transparent)' }}
+        />
+        {backgroundImageUrl && (
+            <div
+                className="absolute inset-0 bg-center bg-no-repeat opacity-100"
+                style={{
+                    ...backgroundImageStyle(backgroundImageUrl),
+                    backgroundSize: 'cover',
+                }}
+            />
+        )}
         <div className="absolute inset-0 opacity-[0.025]" style={{ backgroundImage: GRID_TEXTURE }} />
     </div>
 );
 
 /** Subtle ambient background for authenticated app shell */
-export const AppAmbientBackground: React.FC = () => (
-    <div className="pointer-events-none fixed inset-0 bg-background -z-10">
+export const AppAmbientBackground: React.FC<{ backgroundImageUrl?: string }> = ({ backgroundImageUrl }) => (
+    <div className="pointer-events-none fixed inset-0 bg-background z-0">
         <div className="absolute -top-40 -left-20 w-[420px] h-[420px] rounded-full bg-plex/[0.06] blur-[100px]" />
-        <div className="absolute top-1/2 -right-32 w-[360px] h-[360px] rounded-full bg-amber-500/[0.04] blur-[90px]" />
+        <div className="absolute top-1/2 -right-32 w-[360px] h-[360px] rounded-full bg-plex/[0.04] blur-[90px]" />
         <div className="absolute bottom-0 left-1/3 w-[320px] h-[320px] rounded-full bg-plex/[0.03] blur-[80px]" />
-        <div className="absolute inset-0 bg-[radial-gradient(ellipse_70%_40%_at_50%_0%,rgba(229,160,13,0.06),transparent)]" />
+        <div
+            className="absolute inset-0"
+            style={{ backgroundImage: 'radial-gradient(ellipse 70% 40% at 50% 0%, rgb(var(--color-plex) / 0.06), transparent)' }}
+        />
+        {backgroundImageUrl && (
+            <div
+                className="absolute inset-0 bg-center bg-no-repeat opacity-100"
+                style={{
+                    ...backgroundImageStyle(backgroundImageUrl),
+                    backgroundSize: 'cover',
+                }}
+            />
+        )}
         <div className="absolute inset-0 opacity-[0.018]" style={{ backgroundImage: GRID_TEXTURE }} />
     </div>
 );

--- a/client/shared/types.ts
+++ b/client/shared/types.ts
@@ -14,7 +14,10 @@ export interface User {
 
 export interface PlexConfig {
     token: string;
+    mediaServerType?: 'plex' | 'jellyfin';
     serverIdentifier: string;
+    jellyfinUrl?: string;
+    jellyfinApiKey?: string;
     checkIntervalMinutes: number;
     smtpHost: string;
     smtpPort: number;
@@ -32,7 +35,10 @@ export interface PlexConfig {
 
 export interface AppSettings {
     token?: string;
+    mediaServerType?: 'plex' | 'jellyfin';
     serverIdentifier?: string;
+    jellyfinUrl?: string;
+    jellyfinApiKey?: string;
     checkIntervalMinutes: number;
     smtpHost?: string;
     smtpPort?: number;
@@ -54,7 +60,11 @@ export interface AppSettings {
     radarrApiKey?: string;
     tautulliUrl?: string;
     tautulliApiKey?: string;
+    jellystatUrl?: string;
+    jellystatApiKey?: string;
     primaryColor?: string;
+    customLogoUrl?: string;
+    backgroundImageUrl?: string;
     navOrder?: string[];
 }
 

--- a/index.js
+++ b/index.js
@@ -136,6 +136,7 @@ const createRateLimiter = (windowMs, maxRequests) => {
 };
 const authRateLimit = createRateLimiter(15 * 60 * 1000, 10); // Reduced from 20 — tighter brute-force window
 const authCallbackRateLimit = createRateLimiter(15 * 60 * 1000, 40);
+const jellyfinQuickConnectPollRateLimit = createRateLimiter(5 * 60 * 1000, 140);
 const publicReadRateLimit = createRateLimiter(60 * 1000, 120);
 const speedtestRateLimit = createRateLimiter(60 * 1000, 12);
 const setupRateLimit = createRateLimiter(15 * 60 * 1000, 30);
@@ -287,6 +288,40 @@ let healthData = {};
 const SPEED_TEST_CHUNK_SIZE = 1024 * 1024;
 const SPEED_TEST_BUFFER = Buffer.alloc(SPEED_TEST_CHUNK_SIZE, 'x');
 
+const createDefaultStatusConfig = (config = {}) => {
+    const groups = [
+        { id: 'core', name: 'Core Infrastructure', order: 0 },
+        { id: 'media', name: 'Media Stack', order: 1 },
+        { id: 'downloads', name: 'Download Clients', order: 2 },
+        { id: 'external', name: 'External Services', order: 3 },
+    ];
+    const services = [];
+    const addService = (id, name, url, groupId, description = '') => {
+        if (!url) return;
+        services.push({ id, name, url, type: 'web', groupId, description });
+    };
+
+    const publicDomain = String(config.publicDomain || '').trim();
+    if (publicDomain) addService('portal', 'Server Portal', `${publicDomain.replace(/\/+$/, '')}/api/health`, 'core', 'Portal API health');
+
+    const mediaServerType = String(config.mediaServerType || 'plex').toLowerCase();
+    if (mediaServerType === 'jellyfin') {
+        addService('jellyfin', 'Jellyfin', config.jellyfinUrl, 'media', 'Jellyfin media server');
+        addService('jellystat', 'Jellystat', config.jellystatUrl, 'media', 'Jellyfin analytics');
+    } else {
+        addService('plex', 'Plex', config.plexServerUrl || config.publicDomain, 'media', 'Plex Media Server');
+        addService('tautulli', 'Tautulli', config.tautulliUrl, 'media', 'Plex analytics');
+    }
+
+    addService('sonarr', 'Sonarr', config.sonarrUrl, 'downloads', 'TV automation');
+    addService('radarr', 'Radarr', config.radarrUrl, 'downloads', 'Movie automation');
+    if (config.requestAppType && config.requestAppType !== 'none') {
+        addService(config.requestAppType, config.requestAppType === 'jellyseerr' ? 'Jellyseerr' : 'Seerr', config.requestAppUrl, 'external', 'Requests portal');
+    }
+
+    return { groups, services, announcement: null };
+};
+
 // --- Helper Functions ---
 const log = (message) => console.log(`[${new Date().toISOString()}] ${message}`);
 
@@ -353,7 +388,8 @@ const withCache = async (key, ttlMs, fetcher) => {
 const isDeletedUser = (deletedUsers, user) => {
     const ids = [
         normalized(user.id),
-        normalized(user.plexId)
+        normalized(user.plexId),
+        normalized(user.jellyfinId)
     ].filter(Boolean);
     const email = normalized(user.email);
     const username = normalized(user.username);
@@ -361,7 +397,8 @@ const isDeletedUser = (deletedUsers, user) => {
     return deletedUsers.some(deletedUser => {
         const deletedIds = [
             normalized(deletedUser.id),
-            normalized(deletedUser.plexId)
+            normalized(deletedUser.plexId),
+            normalized(deletedUser.jellyfinId)
         ].filter(Boolean);
 
         return (
@@ -379,6 +416,7 @@ const rememberDeletedUser = async (user, deletedBy) => {
             blockId: randomUUID(),
             id: user.id,
             plexId: user.plexId || user.id,
+            jellyfinId: user.jellyfinId || null,
             username: user.username,
             email: user.email,
             deletedAt: new Date().toISOString(),
@@ -639,6 +677,24 @@ const apiFetch = (url, token, options = {}) => {
     return fetch(url, { ...options, headers });
 };
 
+const jellyfinAuthorizationHeader = (token = '') => {
+    const parts = [
+        'MediaBrowser Client="Server Manager Portal"',
+        'Device="Web"',
+        `DeviceId="${CLIENT_ID}"`,
+        `Version="${appVersion}"`,
+    ];
+    if (token) parts.push(`Token="${token}"`);
+    return parts.join(', ');
+};
+
+const jellyfinHeaders = (token = '', extra = {}) => ({
+    Accept: 'application/json',
+    'X-Emby-Authorization': jellyfinAuthorizationHeader(token),
+    ...(token ? { 'X-Emby-Token': token } : {}),
+    ...extra,
+});
+
 let cachedAdminId = null;
 
 const syncAdminPlexIdFromConfigToken = async (config, { persist = false } = {}) => {
@@ -681,16 +737,20 @@ const findLocalUserForSession = (users, sessionUser) => {
     if (!sessionUser || !Array.isArray(users)) return null;
     const sessionId = normalized(sessionUser.id);
     const sessionPlexId = normalized(sessionUser.plexId);
+    const sessionJellyfinId = normalized(sessionUser.jellyfinId);
     const sessionEmail = normalized(sessionUser.email);
     const sessionUsername = normalized(sessionUser.username);
     return users.find((user) => {
         const userId = normalized(user.id);
         const userPlexId = normalized(user.plexId);
+        const userJellyfinId = normalized(user.jellyfinId);
         const userEmail = normalized(user.email);
         const userUsername = normalized(user.username);
         return (
             (sessionPlexId && (sessionPlexId === userPlexId || sessionPlexId === userId)) ||
+            (sessionJellyfinId && (sessionJellyfinId === userJellyfinId || sessionJellyfinId === userId)) ||
             (sessionId && (sessionId === userId || sessionId === userPlexId)) ||
+            (sessionId && (sessionId === userJellyfinId || sessionId === `jellyfin:${userJellyfinId}`)) ||
             (sessionEmail && sessionEmail === userEmail) ||
             (sessionUsername && sessionUsername === userUsername)
         );
@@ -698,11 +758,36 @@ const findLocalUserForSession = (users, sessionUser) => {
 };
 
 const resolveCurrentAdmin = async (sessionUser, config = null) => {
-    if (!sessionUser?.plexId) return false;
     const loadedConfig = config || await loadFile(CONFIG_PATH, {});
+    if (String(loadedConfig?.mediaServerType || '').toLowerCase() === 'jellyfin') {
+        if (sessionUser?.authProvider !== 'jellyfin' || !sessionUser?.jellyfinId) return false;
+        if (loadedConfig?.jellyfinUrl && loadedConfig?.jellyfinApiKey) {
+            try {
+                const baseUrl = resolveIntegrationUrlForFetch(loadedConfig.jellyfinUrl);
+                const userRes = await fetch(`${baseUrl}/Users/${encodeURIComponent(sessionUser.jellyfinId)}`, {
+                    headers: jellyfinHeaders(loadedConfig.jellyfinApiKey),
+                });
+                if (userRes.ok) {
+                    const jellyfinUser = await userRes.json();
+                    return jellyfinUser?.Policy?.IsAdministrator === true;
+                }
+            } catch (e) {
+                log(`Jellyfin admin policy check failed for ${sessionUser.username || sessionUser.jellyfinId}: ${e.message}`);
+            }
+        }
+        return sessionUser?.jellyfinIsAdmin === true || sessionUser?.isAdmin === true;
+    }
+    if (!sessionUser?.plexId) return false;
     const adminId = await getAdminId(loadedConfig);
     return !!(adminId && String(sessionUser.plexId) === String(adminId));
 };
+
+const isPlexConfigured = (config = {}) => !!(config && config.plexToken && config.serverIdentifier);
+const isJellyfinConfigured = (config = {}) => (
+    String(config?.mediaServerType || '').toLowerCase() === 'jellyfin'
+    && !!(config?.jellyfinUrl && config?.jellyfinApiKey)
+);
+const isPortalConfigured = (config = {}) => isPlexConfigured(config) || isJellyfinConfigured(config);
 
 const requireAuth = (req, res, next) => {
     const token = req.cookies.session;
@@ -747,7 +832,7 @@ const requireAdmin = async (req, res, next) => {
     }
 
     const config = await loadFile(CONFIG_PATH, {});
-    if (!config?.plexToken || !config?.serverIdentifier) {
+    if (!isPortalConfigured(config)) {
         return res.status(403).json({ error: 'Forbidden: App not configured' });
     }
 
@@ -854,6 +939,104 @@ const syncUsers = async (config) => {
     const message = `Sync complete. Synced ${plexUsers.length} users.`;
     log(message);
     return { message, count: plexUsers.length };
+};
+
+const syncJellyfinUsers = async (config) => {
+    log('Starting user sync from Jellyfin...');
+    if (!isJellyfinConfigured(config)) {
+        throw new Error('Jellyfin is not configured.');
+    }
+
+    const baseUrl = resolveIntegrationUrlForFetch(config.jellyfinUrl);
+    const response = await fetchWithTimeout(`${baseUrl}/Users`, {
+        headers: jellyfinHeaders(config.jellyfinApiKey),
+    }, 15000);
+    if (!response.ok) {
+        const detail = await response.text().catch(() => '');
+        log(`Error fetching Jellyfin users. Status: ${response.status}. Response: ${detail}`);
+        throw new Error(`Failed to fetch Jellyfin users. Status: ${response.status}`);
+    }
+
+    const jellyfinUsers = (await response.json())
+        .filter((user) => user?.Id && user?.Name)
+        .map((user) => ({
+            id: `jellyfin:${user.Id}`,
+            jellyfinId: user.Id,
+            username: user.Name,
+            email: '',
+            thumb: user.PrimaryImageTag ? withBasePath(`/api/jellyfin/user-image?userId=${encodeURIComponent(user.Id)}`) : null,
+            isDisabled: user.Policy?.IsDisabled === true,
+            isAdmin: user.Policy?.IsAdministrator === true,
+        }));
+
+    const localUsers = await loadFile(USERS_PATH, []);
+    const deletedUsers = await loadFile(DELETED_USERS_PATH, []);
+    const existingUserMap = new Map(localUsers.map((user) => [String(user.id), user]));
+    const jellyfinIdUserMap = new Map(localUsers.filter((user) => user.jellyfinId).map((user) => [String(user.jellyfinId), user]));
+    const usernameUserMap = new Map(localUsers.filter((user) => user.username).map((user) => [user.username.toLowerCase(), user]));
+    const matchedLocalUserIds = new Set();
+
+    const syncedUsers = jellyfinUsers.map((jUser) => {
+        const deletedLookup = { id: jUser.id, jellyfinId: jUser.jellyfinId, username: jUser.username, email: jUser.email };
+        if (isDeletedUser(deletedUsers, deletedLookup)) {
+            log(`Skipping deleted Jellyfin user during sync: ${jUser.username}`);
+            return null;
+        }
+
+        const existingUser =
+            existingUserMap.get(String(jUser.id)) ||
+            jellyfinIdUserMap.get(String(jUser.jellyfinId)) ||
+            usernameUserMap.get(jUser.username.toLowerCase());
+
+        const accessStatus = jUser.isDisabled ? 'revoked' : 'active';
+        if (existingUser) {
+            matchedLocalUserIds.add(existingUser.id);
+            return {
+                ...existingUser,
+                id: jUser.id,
+                jellyfinId: jUser.jellyfinId,
+                username: jUser.username,
+                email: existingUser.email || '',
+                thumb: jUser.thumb,
+                authProvider: 'jellyfin',
+                plexAccessStatus: accessStatus,
+            };
+        }
+
+        log(`New Jellyfin user found: ${jUser.username}. Setting default 1-day expiry.`);
+        appendAuditLog('jellyfin_sync_new_user_added', null, jUser).catch(() => { });
+        return {
+            id: jUser.id,
+            jellyfinId: jUser.jellyfinId,
+            authProvider: 'jellyfin',
+            username: jUser.username,
+            email: '',
+            thumb: jUser.thumb,
+            joiningDate: new Date().toISOString(),
+            expiryDate: jUser.isAdmin ? null : addDays(new Date(), 1).toISOString(),
+            plexAccessStatus: accessStatus,
+            isTrial: false,
+        };
+    }).filter(Boolean);
+
+    for (const localUser of localUsers) {
+        const belongsToJellyfin = localUser.authProvider === 'jellyfin' || localUser.jellyfinId || String(localUser.id || '').startsWith('jellyfin:');
+        if (!belongsToJellyfin) {
+            syncedUsers.push(localUser);
+            continue;
+        }
+        if (!matchedLocalUserIds.has(localUser.id)) {
+            if (localUser.plexAccessStatus !== 'pending') {
+                localUser.plexAccessStatus = 'revoked';
+            }
+            syncedUsers.push(localUser);
+        }
+    }
+
+    await saveFile(USERS_PATH, syncedUsers);
+    const message = `Sync complete. Synced ${jellyfinUsers.length} Jellyfin users.`;
+    log(message);
+    return { message, count: jellyfinUsers.length };
 };
 
 const revokePlexAccess = async (user, config) => {
@@ -1304,6 +1487,193 @@ app.post('/api/auth/plex/login', authRateLimit, async (req, res) => {
     }
 });
 
+const jellyfinQuickConnectSessions = new Map();
+
+const pruneJellyfinQuickConnectSessions = () => {
+    const now = Date.now();
+    jellyfinQuickConnectSessions.forEach((session, id) => {
+        if (!session?.expiresAt || session.expiresAt <= now) {
+            jellyfinQuickConnectSessions.delete(id);
+        }
+    });
+};
+
+const completeJellyfinPortalLogin = async (req, res, config, authData, source = 'password') => {
+    const jellyfinUser = authData?.User || authData?.user || {};
+    const accessToken = authData?.AccessToken || authData?.accessToken || '';
+    const userId = jellyfinUser.Id || jellyfinUser.Id || jellyfinUser.id || '';
+    const username = jellyfinUser.Name || jellyfinUser.name || 'Jellyfin User';
+    const isAdmin = jellyfinUser?.Policy?.IsAdministrator === true || jellyfinUser?.policy?.isAdministrator === true;
+    const sessionUser = {
+        id: userId ? `jellyfin:${userId}` : `jellyfin:${username}`,
+        jellyfinId: userId,
+        authProvider: 'jellyfin',
+        username,
+        email: '',
+        thumb: userId ? withBasePath(`/api/jellyfin/user-image?userId=${encodeURIComponent(userId)}`) : null,
+        jellyfinIsAdmin: isAdmin,
+        isAdmin,
+    };
+
+    const deletedUsers = await loadFile(DELETED_USERS_PATH, []);
+    if (!isAdmin && isDeletedUser(deletedUsers, sessionUser)) {
+        await appendAuditLog('login_blocked_deleted_user', sessionUser, sessionUser);
+        clearSessionCookie(req, res);
+        return res.status(403).json({ error: 'Your portal session has expired. Please contact the admin for access.' });
+    }
+
+    const users = await loadFile(USERS_PATH, []);
+    const knownUser = findLocalUserForSession(users, sessionUser);
+    if (!isAdmin && !knownUser) {
+        await appendAuditLog('login_blocked_non_member', sessionUser, sessionUser);
+        clearSessionCookie(req, res);
+        log(`Jellyfin ${source} login blocked for ${sessionUser.username}: not a portal member`);
+        return res.status(403).json({ error: 'Your account is not registered for this portal.' });
+    }
+
+    if (!isAdmin && knownUser) {
+        knownUser.lastLogin = new Date().toISOString();
+        if (!knownUser.jellyfinId && sessionUser.jellyfinId) knownUser.jellyfinId = sessionUser.jellyfinId;
+        await saveFile(USERS_PATH, users);
+    }
+
+    const token = jwt.sign(sessionUser, JWT_SECRET, { expiresIn: '7d' });
+    setSessionCookie(req, res, token);
+    await appendAuditLog('user_login', sessionUser, sessionUser);
+    log(`Jellyfin ${source} login success for ${sessionUser.username} (admin=${isAdmin}, secureCookie=${FORCE_SECURE_COOKIES}, token=${accessToken ? 'received' : 'missing'})`);
+    return res.json({ success: true, user: { username: sessionUser.username, jellyfinId: sessionUser.jellyfinId, isAdmin } });
+};
+
+app.post('/api/auth/jellyfin/login', authRateLimit, async (req, res) => {
+    const { username, password } = req.body || {};
+    if (!username || !password) {
+        return res.status(400).json({ error: 'Username and password are required' });
+    }
+
+    try {
+        const config = await loadFile(CONFIG_PATH, {});
+        if (!isJellyfinConfigured(config)) {
+            return res.status(400).json({ error: 'Jellyfin authentication is not configured' });
+        }
+
+        const baseUrl = resolveIntegrationUrlForFetch(config.jellyfinUrl);
+        const response = await fetch(`${baseUrl}/Users/AuthenticateByName`, {
+            method: 'POST',
+            headers: jellyfinHeaders('', { 'Content-Type': 'application/json' }),
+            body: JSON.stringify({ Username: username, Pw: password }),
+        });
+
+        if (!response.ok) {
+            const detail = await response.text().catch(() => '');
+            log(`Jellyfin login failed for ${username}: ${response.status} ${detail.slice(0, 120)}`);
+            return res.status(401).json({ error: 'Invalid Jellyfin username or password' });
+        }
+
+        return completeJellyfinPortalLogin(req, res, config, await response.json(), 'password');
+    } catch (err) {
+        log('Error in jellyfin login: ' + err.message);
+        res.status(500).json({ error: 'Failed to authenticate with Jellyfin' });
+    }
+});
+
+app.post('/api/auth/jellyfin/quick-connect/initiate', authRateLimit, async (req, res) => {
+    try {
+        pruneJellyfinQuickConnectSessions();
+        const config = await loadFile(CONFIG_PATH, {});
+        if (!isJellyfinConfigured(config)) {
+            return res.status(400).json({ error: 'Jellyfin authentication is not configured' });
+        }
+
+        const baseUrl = resolveIntegrationUrlForFetch(config.jellyfinUrl);
+        const enabledRes = await fetch(`${baseUrl}/QuickConnect/Enabled`, {
+            headers: jellyfinHeaders(''),
+        });
+        if (enabledRes.ok) {
+            const enabledText = await enabledRes.text();
+            if (String(enabledText).trim().toLowerCase() === 'false') {
+                return res.status(400).json({ error: 'Quick Connect is disabled on your Jellyfin server.' });
+            }
+        }
+
+        const initiateRes = await fetch(`${baseUrl}/QuickConnect/Initiate`, {
+            method: 'POST',
+            headers: jellyfinHeaders(''),
+        });
+        if (!initiateRes.ok) {
+            const detail = await initiateRes.text().catch(() => '');
+            log(`Jellyfin Quick Connect initiate failed: ${initiateRes.status} ${detail.slice(0, 160)}`);
+            return res.status(502).json({ error: 'Failed to start Jellyfin Quick Connect.' });
+        }
+
+        const state = await initiateRes.json();
+        const secret = state.Secret || state.secret;
+        const code = state.Code || state.code;
+        if (!secret || !code) {
+            return res.status(502).json({ error: 'Jellyfin did not return a Quick Connect code.' });
+        }
+
+        const sessionId = randomUUID();
+        jellyfinQuickConnectSessions.set(sessionId, {
+            secret,
+            baseUrl,
+            expiresAt: Date.now() + 5 * 60 * 1000,
+        });
+        res.json({ sessionId, code, jellyfinUrl: config.jellyfinUrl });
+    } catch (err) {
+        log('Error starting jellyfin quick connect: ' + err.message);
+        res.status(500).json({ error: 'Failed to start Jellyfin Quick Connect' });
+    }
+});
+
+app.post('/api/auth/jellyfin/quick-connect/poll', jellyfinQuickConnectPollRateLimit, async (req, res) => {
+    const { sessionId } = req.body || {};
+    if (!sessionId) return res.status(400).json({ error: 'sessionId is required' });
+
+    try {
+        pruneJellyfinQuickConnectSessions();
+        const quickSession = jellyfinQuickConnectSessions.get(sessionId);
+        if (!quickSession) {
+            return res.status(404).json({ error: 'Quick Connect session expired. Please try again.' });
+        }
+
+        const config = await loadFile(CONFIG_PATH, {});
+        if (!isJellyfinConfigured(config)) {
+            return res.status(400).json({ error: 'Jellyfin authentication is not configured' });
+        }
+
+        const stateRes = await fetch(`${quickSession.baseUrl}/QuickConnect/Connect?secret=${encodeURIComponent(quickSession.secret)}`, {
+            headers: jellyfinHeaders(''),
+        });
+        if (!stateRes.ok) {
+            const detail = await stateRes.text().catch(() => '');
+            log(`Jellyfin Quick Connect poll failed: ${stateRes.status} ${detail.slice(0, 160)}`);
+            return res.status(502).json({ error: 'Failed to check Jellyfin Quick Connect status.' });
+        }
+        const state = await stateRes.json();
+        const authenticated = state.Authenticated === true || state.authenticated === true;
+        if (!authenticated) {
+            return res.json({ authenticated: false });
+        }
+
+        const authRes = await fetch(`${quickSession.baseUrl}/Users/AuthenticateWithQuickConnect`, {
+            method: 'POST',
+            headers: jellyfinHeaders('', { 'Content-Type': 'application/json' }),
+            body: JSON.stringify({ Secret: quickSession.secret }),
+        });
+        if (!authRes.ok) {
+            const detail = await authRes.text().catch(() => '');
+            log(`Jellyfin Quick Connect token exchange failed: ${authRes.status} ${detail.slice(0, 160)}`);
+            return res.status(502).json({ error: 'Jellyfin approved the code, but token exchange failed.' });
+        }
+
+        jellyfinQuickConnectSessions.delete(sessionId);
+        return completeJellyfinPortalLogin(req, res, config, await authRes.json(), 'quick-connect');
+    } catch (err) {
+        log('Error polling jellyfin quick connect: ' + err.message);
+        res.status(500).json({ error: 'Failed to finish Jellyfin Quick Connect' });
+    }
+});
+
 const fetchPlexPinAuthToken = async (pinId, { attempts = 10, delayMs = 800 } = {}) => {
     let lastData = null;
     for (let attempt = 1; attempt <= attempts; attempt++) {
@@ -1441,7 +1811,7 @@ app.get('/api/auth/diagnostics', publicReadRateLimit, async (req, res) => {
     res.json({
         appVersion,
         forceSecureCookies: FORCE_SECURE_COOKIES,
-        configured: !!(config?.plexToken && config?.serverIdentifier),
+        configured: isPortalConfigured(config),
         hasAdminPlexId: !!config?.adminPlexId,
         plexServerUrlConfigured: !!resolveConfiguredPlexServerUrl(config),
         dockerRuntime: fsSync.existsSync('/.dockerenv'),
@@ -1461,6 +1831,8 @@ app.get('/api/auth/session', publicReadRateLimit, async (req, res) => {
             user: {
                 username: user.username,
                 plexId: user.plexId,
+                jellyfinId: user.jellyfinId,
+                authProvider: user.authProvider || 'plex',
                 isAdmin,
             },
         });
@@ -1496,7 +1868,7 @@ app.get('/api/auth/plex/callback', authCallbackRateLimit, async (req, res) => {
 
 const assertInitialSetupAccess = async (req, res, options = {}) => {
     const existingConfig = await loadFile(CONFIG_PATH, {});
-    const isConfigured = !!(existingConfig?.plexToken && existingConfig?.serverIdentifier);
+    const isConfigured = isPortalConfigured(existingConfig);
     if (isConfigured) {
         res.status(403).json({ error: 'Portal is already configured.' });
         return false;
@@ -1591,18 +1963,20 @@ app.get('/api/users/me', requireAuth, async (req, res) => {
         return res.status(403).json({ error: 'Your portal session has expired. Please contact the admin for access.' });
     }
 
-    let serverName = 'Plex Server';
+    const isJellyfinPortal = String(config?.mediaServerType || '').toLowerCase() === 'jellyfin';
+    let serverName = isJellyfinPortal ? 'Jellyfin Server' : 'Plex Server';
     let adminThumb = null;
     let sessionThumb = req.user.thumb || null;
-    let requestUrl = 'https://yourdomain.com';
-    let navOrder = ['home', 'discover', 'users', 'status', 'analytics', 'mediastack', 'maintenance', 'request', 'settings', 'logout'];
+    let requestUrl = config.requestUrl || 'https://yourdomain.com';
+    let navOrder = config.navOrder || ['home', 'discover', 'users', 'status', 'analytics', 'mediastack', 'maintenance', 'request', 'settings', 'logout'];
     try {
-        if (config && config.plexToken && config.serverIdentifier) {
+        if (isJellyfinPortal && config?.jellyfinUrl && config?.jellyfinApiKey) {
+            const profile = await getAdminProfile(config);
+            serverName = profile.serverName || 'Jellyfin Server';
+        } else if (config && config.plexToken && config.serverIdentifier) {
             const profile = await getAdminProfile(config);
             serverName = profile.serverName || 'Plex Server';
             adminThumb = profile.thumb;
-            requestUrl = config.requestUrl || 'https://yourdomain.com';
-            if (config.navOrder) navOrder = config.navOrder;
 
             if (!sessionThumb) {
                 const uri = await getPlexConnectionUri(config);
@@ -1622,6 +1996,7 @@ app.get('/api/users/me', requireAuth, async (req, res) => {
         account: localUser || null,
         serverName,
         adminThumb,
+        mediaServerType: config.mediaServerType || 'plex',
         requestUrl,
         navOrder
     });
@@ -1679,7 +2054,7 @@ const normalizeSectionLayout = (raw) => {
 // Config endpoints
 app.get('/api/config', requireAdmin, async (req, res) => {
     const config = await loadFile(CONFIG_PATH, {});
-    const isConfigured = !!(config && config.plexToken && config.serverIdentifier);
+    const isConfigured = isPortalConfigured(config);
         const contactWhatsApp = config.contactWhatsApp || '';
         const contactEmail = config.contactEmail || '';
 
@@ -1688,8 +2063,11 @@ app.get('/api/config', requireAdmin, async (req, res) => {
             configured: true,
             settings: {
                 token: config.plexToken ? SECRET_MASK : '',
+                mediaServerType: config.mediaServerType || 'plex',
                 serverIdentifier: config.serverIdentifier,
                 plexServerUrl: config.plexServerUrl || '',
+                jellyfinUrl: config.jellyfinUrl || '',
+                jellyfinApiKey: config.jellyfinApiKey ? SECRET_MASK : '',
                 checkIntervalMinutes: config.checkIntervalMinutes || 60,
                 smtpHost: config.smtpHost || '',
                 smtpPort: config.smtpPort || 587,
@@ -1713,11 +2091,14 @@ app.get('/api/config', requireAdmin, async (req, res) => {
                 radarrApiKey: config.radarrApiKey ? SECRET_MASK : '',
                 tautulliUrl: config.tautulliUrl || '',
                 tautulliApiKey: config.tautulliApiKey ? SECRET_MASK : '',
-                requestAppType: config.requestAppType || 'none',
+                jellystatUrl: config.jellystatUrl || '',
+                jellystatApiKey: config.jellystatApiKey ? SECRET_MASK : '',
+                requestAppType: config.requestAppType === 'overseerr' ? 'seerr' : (config.requestAppType || 'none'),
                 requestAppUrl: config.requestAppUrl || '',
                 requestAppApiKey: config.requestAppApiKey ? SECRET_MASK : '',
-                primaryColor: config.primaryColor || '#E5A00D',
+                primaryColor: config.primaryColor || '#F7C600',
                 customLogoUrl: config.customLogoUrl || '',
+                backgroundImageUrl: config.backgroundImageUrl || '',
                 referralEnabled: !!config.referralEnabled,
                 referralTrialDays: config.referralTrialDays || 3,
                 referralRewardDays: config.referralRewardDays || 7,
@@ -1740,8 +2121,11 @@ app.get('/api/config', requireAdmin, async (req, res) => {
             configured: false,
             settings: {
                 token: '',
+                mediaServerType: 'plex',
                 serverIdentifier: '',
                 plexServerUrl: '',
+                jellyfinUrl: '',
+                jellyfinApiKey: '',
                 checkIntervalMinutes: 60,
                 smtpHost: '',
                 smtpPort: 587,
@@ -1763,11 +2147,14 @@ app.get('/api/config', requireAdmin, async (req, res) => {
                 radarrApiKey: '',
                 tautulliUrl: '',
                 tautulliApiKey: '',
+                jellystatUrl: '',
+                jellystatApiKey: '',
                 requestAppType: 'none',
                 requestAppUrl: '',
                 requestAppApiKey: '',
-                primaryColor: '#E5A00D',
+                primaryColor: '#F7C600',
                 customLogoUrl: '',
+                backgroundImageUrl: '',
                 referralEnabled: false,
                 referralTrialDays: 3,
                 referralRewardDays: 7,
@@ -1790,27 +2177,32 @@ app.get('/api/config', requireAdmin, async (req, res) => {
 
 app.post('/api/config', setupRateLimit, async (req, res) => {
     const {
-        token, serverIdentifier, checkIntervalMinutes,
-        plexServerUrl: plexServerUrlFromBody,
+        token, mediaServerType, serverIdentifier, checkIntervalMinutes,
+        plexServerUrl: plexServerUrlFromBody, jellyfinUrl, jellyfinApiKey,
         smtpHost, smtpPort, smtpUser, smtpPass, smtpFrom, smtpSecure, emailDaysBefore,
         newsletterFrequency, newsletterDay, publicDomain, requestUrl, contactUrl, contactWhatsApp, contactEmail,
-        sonarrUrl, sonarrApiKey, radarrUrl, radarrApiKey, tautulliUrl, tautulliApiKey,
+        sonarrUrl, sonarrApiKey, radarrUrl, radarrApiKey, tautulliUrl, tautulliApiKey, jellystatUrl, jellystatApiKey,
         requestAppType, requestAppUrl, requestAppApiKey,
         inactiveCleanupEnabled, inactiveCleanupDays,
-        primaryColor, customLogoUrl, referralEnabled, referralTrialDays, referralRewardDays, announcement, navOrder, hideStreamUsers, defaultLibraryIds, use24HourClock, allowTemporaryAccess, showPosterQualityBadges,
+        primaryColor, customLogoUrl, backgroundImageUrl, referralEnabled, referralTrialDays, referralRewardDays, announcement, navOrder, hideStreamUsers, defaultLibraryIds, use24HourClock, allowTemporaryAccess, showPosterQualityBadges,
         autoBackupEnabled, autoBackupIntervalDays, autoBackupRetentionCount, maintenanceExperimentalEnabled, dashboardLayout
     } = req.body;
 
-    if (!token || !serverIdentifier) {
-        return res.status(400).json({ error: 'Token and serverIdentifier are required.' });
-    }
-
+    const existingConfig = await loadFile(CONFIG_PATH, {});
+    const normalizedMediaServerType = ['plex', 'jellyfin'].includes(String(mediaServerType || '').toLowerCase())
+        ? String(mediaServerType || '').toLowerCase()
+        : (existingConfig.mediaServerType || 'plex');
     const normalizedToken = normalizePlexToken(token);
     const normalizedServerIdentifier = String(serverIdentifier).trim();
-
-    const existingConfig = await loadFile(CONFIG_PATH, {});
-    const isConfigured = !!(existingConfig && existingConfig.plexToken && existingConfig.serverIdentifier);
+    const isConfigured = isPortalConfigured(existingConfig);
     const wasMaintenanceEnabled = !!existingConfig.maintenanceExperimentalEnabled;
+
+    if (normalizedMediaServerType === 'plex' && (!normalizedToken || !normalizedServerIdentifier)) {
+        return res.status(400).json({ error: 'Plex token and serverIdentifier are required.' });
+    }
+    if (normalizedMediaServerType === 'jellyfin' && (!jellyfinUrl || !jellyfinApiKey)) {
+        return res.status(400).json({ error: 'Jellyfin URL and API key are required.' });
+    }
 
     if (isConfigured) {
         const sessionToken = req.cookies && req.cookies.session;
@@ -1828,6 +2220,9 @@ app.post('/api/config', setupRateLimit, async (req, res) => {
             return res.status(403).json({ error: 'Forbidden: Invalid or expired session. Please log in again.' });
         }
     } else if (!canRunInitialSetup(req)) {
+        if (normalizedMediaServerType === 'jellyfin') {
+            return res.status(403).json({ error: 'Initial setup is restricted. Configure SETUP_TOKEN or run setup from localhost.' });
+        }
         const candidatePlexServerUrl = (plexServerUrlFromBody !== undefined
             ? String(plexServerUrlFromBody || '').trim()
             : String(existingConfig.plexServerUrl || '').trim()) || resolveConfiguredPlexServerUrl(existingConfig);
@@ -1843,7 +2238,9 @@ app.post('/api/config', setupRateLimit, async (req, res) => {
     let safeSonarrUrl = '';
     let safeRadarrUrl = '';
     let safeTautulliUrl = '';
+    let safeJellystatUrl = '';
     let safeRequestAppUrl = '';
+    let safeJellyfinUrl = '';
     const resolveConfigIntegrationUrl = (incoming, existing) => {
         const existingValue = typeof existing === 'string' ? existing : '';
         // Keep existing URL as-is when caller did not change the value.
@@ -1857,7 +2254,9 @@ app.post('/api/config', setupRateLimit, async (req, res) => {
         safeSonarrUrl = resolveConfigIntegrationUrl(sonarrUrl, existingConfig.sonarrUrl || '');
         safeRadarrUrl = resolveConfigIntegrationUrl(radarrUrl, existingConfig.radarrUrl || '');
         safeTautulliUrl = resolveConfigIntegrationUrl(tautulliUrl, existingConfig.tautulliUrl || '');
+        safeJellystatUrl = resolveConfigIntegrationUrl(jellystatUrl, existingConfig.jellystatUrl || '');
         safeRequestAppUrl = resolveConfigIntegrationUrl(requestAppUrl, existingConfig.requestAppUrl || '');
+        safeJellyfinUrl = resolveConfigIntegrationUrl(jellyfinUrl, existingConfig.jellyfinUrl || '');
     } catch (e) {
         return res.status(400).json({ error: `Invalid integration URL: ${e.message}` });
     }
@@ -1872,9 +2271,12 @@ app.post('/api/config', setupRateLimit, async (req, res) => {
 
     const config = {
         ...existingConfig,
-        plexToken: resolveSecret(normalizedToken, existingConfig.plexToken),
-        serverIdentifier: normalizedServerIdentifier,
+        mediaServerType: normalizedMediaServerType,
+        plexToken: normalizedMediaServerType === 'jellyfin' ? resolveSecret(token, existingConfig.plexToken) : resolveSecret(normalizedToken, existingConfig.plexToken),
+        serverIdentifier: normalizedMediaServerType === 'jellyfin' ? (normalizedServerIdentifier || existingConfig.serverIdentifier || '') : normalizedServerIdentifier,
         plexServerUrl: (plexServerUrlFromBody !== undefined ? String(plexServerUrlFromBody || '').trim() : existingConfig.plexServerUrl) || '',
+        jellyfinUrl: safeJellyfinUrl,
+        jellyfinApiKey: resolveSecret(jellyfinApiKey, existingConfig.jellyfinApiKey),
         checkIntervalMinutes: (interval > 0 ? interval : 60),
         smtpHost: smtpHost || '',
         smtpPort: parseInt(smtpPort, 10) || 587,
@@ -1898,11 +2300,14 @@ app.post('/api/config', setupRateLimit, async (req, res) => {
         radarrApiKey: resolveSecret(radarrApiKey, existingConfig.radarrApiKey),
         tautulliUrl: safeTautulliUrl,
         tautulliApiKey: resolveSecret(tautulliApiKey, existingConfig.tautulliApiKey),
-        requestAppType: ['none', 'overseerr', 'jellyseerr', 'ombi'].includes(String(requestAppType || '').toLowerCase()) ? String(requestAppType).toLowerCase() : (existingConfig.requestAppType || 'none'),
+        jellystatUrl: safeJellystatUrl,
+        jellystatApiKey: resolveSecret(jellystatApiKey, existingConfig.jellystatApiKey),
+        requestAppType: ['none', 'seerr', 'overseerr', 'jellyseerr', 'ombi'].includes(String(requestAppType || '').toLowerCase()) ? (String(requestAppType).toLowerCase() === 'overseerr' ? 'seerr' : String(requestAppType).toLowerCase()) : (existingConfig.requestAppType || 'none'),
         requestAppUrl: safeRequestAppUrl,
         requestAppApiKey: resolveSecret(requestAppApiKey, existingConfig.requestAppApiKey),
-        primaryColor: primaryColor || '#E5A00D',
+        primaryColor: primaryColor || '#F7C600',
         customLogoUrl: customLogoUrl || '',
+        backgroundImageUrl: backgroundImageUrl || '',
         referralEnabled: !!referralEnabled,
         referralTrialDays: parseInt(referralTrialDays, 10) || 3,
         referralRewardDays: parseInt(referralRewardDays, 10) || 7,
@@ -1935,7 +2340,7 @@ app.post('/api/config', setupRateLimit, async (req, res) => {
     systemJobs.autoBackup.nextRun = config.autoBackupEnabled ? computeNextBackupRun(config) : null;
     log('Configuration saved successfully.');
     startBackgroundService(); // (Re)start service with new config
-    const becameConfigured = !isConfigured && !!config.plexToken && !!config.serverIdentifier;
+    const becameConfigured = !isConfigured && isPortalConfigured(config);
     const maintenanceJustEnabled = !wasMaintenanceEnabled && !!config.maintenanceExperimentalEnabled;
     if ((becameConfigured || maintenanceJustEnabled) && !!config.maintenanceExperimentalEnabled) {
         // Kick an immediate index build after setup/enablement so rules are usable right away.
@@ -1955,8 +2360,10 @@ app.get('/api/config/public', async (req, res) => {
     try {
         const config = (await loadFile(CONFIG_PATH, {})) || {};
         res.json({
-            primaryColor: config.primaryColor || '#E5A00D',
+            mediaServerType: config.mediaServerType || 'plex',
+            primaryColor: config.primaryColor || '#F7C600',
             customLogoUrl: config.customLogoUrl || '',
+            backgroundImageUrl: config.backgroundImageUrl || '',
             announcement: config.announcement || '',
             referralEnabled: !!config.referralEnabled,
             appVersion: appVersion,
@@ -1968,8 +2375,10 @@ app.get('/api/config/public', async (req, res) => {
         });
     } catch (error) {
         res.json({
-            primaryColor: '#E5A00D',
+            mediaServerType: 'plex',
+            primaryColor: '#F7C600',
             customLogoUrl: '',
+            backgroundImageUrl: '',
             announcement: '',
             referralEnabled: false,
             appVersion: appVersion,
@@ -2104,7 +2513,7 @@ const testSeerrFamilyConnection = async (baseUrl, apiKey) => {
 
 const assertIntegrationTestAccess = async (req, res) => {
     const stored = await loadFile(CONFIG_PATH, {});
-    const isConfigured = !!(stored.plexToken && stored.serverIdentifier);
+    const isConfigured = isPortalConfigured(stored);
     if (isConfigured) {
         const sessionToken = req.cookies && req.cookies.session;
         if (!sessionToken) {
@@ -2133,9 +2542,11 @@ app.post('/api/config/test-integration', setupRateLimit, async (req, res) => {
     const {
         type,
         token, serverIdentifier, plexServerUrl,
+        jellyfinUrl, jellyfinApiKey,
         sonarrUrl, sonarrApiKey,
         radarrUrl, radarrApiKey,
         tautulliUrl, tautulliApiKey,
+        jellystatUrl, jellystatApiKey,
         requestAppType, requestAppUrl, requestAppApiKey,
     } = req.body || {};
 
@@ -2162,6 +2573,19 @@ app.post('/api/config/test-integration', setupRateLimit, async (req, res) => {
                 ? `Connected to Plex Media Server (v${version})`
                 : 'Connected to Plex Media Server';
             return res.json({ ok: true, message, details: { version: version || null, machineIdentifier: container.machineIdentifier || serverId, uri } });
+        }
+
+        if (type === 'jellyfin') {
+            const url = resolveIntegrationUrlForFetch(resolveTestCredential(jellyfinUrl, stored.jellyfinUrl));
+            const apiKey = resolveTestCredential(jellyfinApiKey, stored.jellyfinApiKey);
+            if (!url || !apiKey) return res.status(400).json({ error: 'Jellyfin URL and API key are required.' });
+            const infoRes = await fetchWithTimeout(`${url}/System/Info`, {
+                headers: { Accept: 'application/json', 'X-Emby-Token': apiKey },
+            }, 12000);
+            if (!infoRes.ok) throw new Error(`Jellyfin returned HTTP ${infoRes.status}`);
+            const data = await infoRes.json().catch(() => ({}));
+            const version = data.Version || data.version || '?';
+            return res.json({ ok: true, message: `Jellyfin v${version} connected`, details: { version, serverName: data.ServerName || data.LocalAddress || null } });
         }
 
         if (type === 'sonarr') {
@@ -2200,6 +2624,18 @@ app.post('/api/config/test-integration', setupRateLimit, async (req, res) => {
             if (payload?.response?.result !== 'success') throw new Error(payload?.response?.message || 'Tautulli API error');
             const info = payload.response.data || {};
             return res.json({ ok: true, message: `Tautulli connected (${info.pms_name || 'Plex'})`, details: { pmsVersion: info.pms_version, pmsPlatform: info.pms_platform } });
+        }
+
+        if (type === 'jellystat') {
+            const url = resolveIntegrationUrlForFetch(resolveTestCredential(jellystatUrl, stored.jellystatUrl));
+            const apiKey = resolveTestCredential(jellystatApiKey, stored.jellystatApiKey);
+            if (!url || !apiKey) return res.status(400).json({ error: 'Jellystat URL and API key are required.' });
+            const statsRes = await fetchWithTimeout(`${url}/stats/getViewsByLibraryType?days=30`, {
+                headers: { Accept: 'application/json', 'X-API-Token': apiKey },
+            }, 12000);
+            if (!statsRes.ok) throw new Error(`Jellystat returned HTTP ${statsRes.status}`);
+            const data = await statsRes.json().catch(() => null);
+            return res.json({ ok: true, message: 'Jellystat connected', details: { sample: data ? true : false } });
         }
 
         if (type === 'requestApp') {
@@ -3107,7 +3543,7 @@ app.post('/api/plex/servers', setupRateLimit, async (req, res) => {
 
     try {
         const existingConfig = await loadFile(CONFIG_PATH, {});
-        const isConfigured = !!(existingConfig && existingConfig.plexToken && existingConfig.serverIdentifier);
+        const isConfigured = isPortalConfigured(existingConfig);
         if (isConfigured) {
             const sessionToken = req.cookies && req.cookies.session;
             if (!sessionToken) {
@@ -3184,12 +3620,13 @@ app.post('/api/plex/servers', setupRateLimit, async (req, res) => {
 app.post('/api/sync', requireAdmin, async (req, res) => {
     const config = await loadFile(CONFIG_PATH, null);
     if (!config) return res.status(400).json({ error: 'App not configured.' });
+    const isJellyfinPortal = String(config.mediaServerType || '').toLowerCase() === 'jellyfin';
     try {
-        const result = await syncUsers(config);
-        await appendAuditLog('plex_sync_completed', req.user || null, null, { count: result.count });
+        const result = isJellyfinPortal ? await syncJellyfinUsers(config) : await syncUsers(config);
+        await appendAuditLog(isJellyfinPortal ? 'jellyfin_sync_completed' : 'plex_sync_completed', req.user || null, null, { count: result.count });
         res.json(result);
     } catch (error) {
-        await appendAuditLog('plex_sync_failed', req.user || null, null, { error: error.message });
+        await appendAuditLog(isJellyfinPortal ? 'jellyfin_sync_failed' : 'plex_sync_failed', req.user || null, null, { error: error.message });
         res.status(500).json({ error: error.message });
     }
 });
@@ -3430,10 +3867,40 @@ app.get('/api/deleted-users', requireAdmin, async (req, res) => {
     res.json(deletedUsers.map(user => ({ ...user, blockId: getDeletedUserKey(user) })));
 });
 
-const getTasksSnapshot = () => [
-    ...tasksInfo.map(task => ({ ...task })),
-    ...Object.values(systemJobs).map(job => ({ ...job }))
-];
+const decorateTaskForConfig = (task, config = {}) => {
+    const mediaServerType = String(config.mediaServerType || 'plex').toLowerCase();
+    const next = { ...task };
+    if (next.id === 'syncPlexUsers') {
+        if (mediaServerType === 'jellyfin') {
+            next.name = 'Sync Jellyfin Users';
+            next.description = 'Fetches latest user data and profile images from Jellyfin.';
+        } else {
+            next.name = 'Sync Plex Users';
+            next.description = 'Fetches latest user data from Plex.';
+        }
+    }
+    if (next.id === 'checkAndRevoke') {
+        next.description = mediaServerType === 'jellyfin'
+            ? 'Revokes expired portal access for Jellyfin users.'
+            : 'Removes Plex access for expired users.';
+    }
+    if (next.id === 'checkAndCleanupInactive') {
+        next.description = mediaServerType === 'jellyfin'
+            ? 'Revokes portal access for Jellyfin users who have not watched anything recently.'
+            : 'Revokes access for users who have not watched anything recently.';
+    }
+    return next;
+};
+
+const getTasksSnapshot = (config = {}) => {
+    const mediaServerType = String(config.mediaServerType || 'plex').toLowerCase();
+    const systemJobList = Object.values(systemJobs)
+        .filter(job => !(mediaServerType === 'jellyfin' && job.id === 'plexStats'));
+    return [
+        ...tasksInfo.map(task => decorateTaskForConfig(task, config)),
+        ...systemJobList.map(job => ({ ...job }))
+    ];
+};
 
 const findRunnableTask = (taskId) => {
     const scheduled = tasksInfo.find(t => t.id === taskId);
@@ -3443,8 +3910,9 @@ const findRunnableTask = (taskId) => {
     return null;
 };
 
-app.get('/api/tasks', requireAdmin, (req, res) => {
-    res.json(getTasksSnapshot());
+app.get('/api/tasks', requireAdmin, async (req, res) => {
+    const config = await loadFile(CONFIG_PATH, {});
+    res.json(getTasksSnapshot(config));
 });
 
 app.post('/api/tasks/run/:taskId', requireAdmin, async (req, res) => {
@@ -3535,11 +4003,14 @@ app.get('/api/admin/diagnostics', requireAdmin, async (req, res) => {
                 configDataDir: CONFIG_DIR
             },
             integrations: {
+                mediaServerType: config.mediaServerType || 'plex',
                 plexConfigured: !!(config.plexToken && config.serverIdentifier),
+                jellyfinConfigured: !!(config.jellyfinUrl && config.jellyfinApiKey),
                 smtpConfigured: !!(config.smtpHost && config.smtpUser && config.smtpPass),
                 sonarrConfigured: !!(config.sonarrUrl && config.sonarrApiKey),
                 radarrConfigured: !!(config.radarrUrl && config.radarrApiKey),
                 tautulliConfigured: !!(config.tautulliUrl && config.tautulliApiKey),
+                jellystatConfigured: !!(config.jellystatUrl && config.jellystatApiKey),
                 requestAppEnabled: !!(config.requestAppType && config.requestAppType !== 'none'),
                 requestAppConfigured: !!(config.requestAppType && config.requestAppType !== 'none' && config.requestAppUrl && config.requestAppApiKey)
             },
@@ -3564,7 +4035,7 @@ app.get('/api/admin/diagnostics', requireAdmin, async (req, res) => {
                 lastRunAt: config.autoBackupLastRunAt || null,
                 availableBackups: backups.length
             },
-            jobs: getTasksSnapshot(),
+            jobs: getTasksSnapshot(config),
             checkedAt: new Date(now).toISOString()
         });
     } catch (e) {
@@ -4032,6 +4503,25 @@ let cachedAdminProfile = null;
 let lastAdminProfileFetch = 0;
 
 async function getAdminProfile(config) {
+    if (String(config?.mediaServerType || '').toLowerCase() === 'jellyfin') {
+        let serverName = 'Jellyfin Server';
+        try {
+            if (config?.jellyfinUrl && config?.jellyfinApiKey) {
+                const baseUrl = resolveIntegrationUrlForFetch(config.jellyfinUrl);
+                const infoRes = await fetch(`${baseUrl}/System/Info`, {
+                    headers: jellyfinHeaders(config.jellyfinApiKey),
+                });
+                if (infoRes.ok) {
+                    const info = await infoRes.json();
+                    serverName = info.ServerName || info.LocalAddress || serverName;
+                }
+            }
+        } catch (e) {
+            log(`Failed to fetch Jellyfin server info: ${e.message}`);
+        }
+        return { thumb: null, serverName };
+    }
+
     if (!config || !config.plexToken) return { thumb: null, serverName: 'Server Portal' };
 
     if (cachedAdminProfile && Date.now() - lastAdminProfileFetch < 3600000) {
@@ -4062,12 +4552,12 @@ app.get('/api/public/info', publicReadRateLimit, async (req, res) => {
     try {
         const config = await loadFile(CONFIG_PATH, {});
         const profile = await getAdminProfile(config);
-        const isConfigured = !!(config && config.plexToken && config.serverIdentifier);
+        const isConfigured = isPortalConfigured(config);
         const contactWhatsApp = config.contactWhatsApp || '';
         const contactEmail = config.contactEmail || '';
-        res.json({ ...profile, isConfigured, requestUrl: config.requestUrl || 'https://yourdomain.com', contactWhatsApp, contactEmail });
+        res.json({ ...profile, isConfigured, mediaServerType: config.mediaServerType || 'plex', requestUrl: config.requestUrl || 'https://yourdomain.com', contactWhatsApp, contactEmail });
     } catch (e) {
-        res.json({ thumb: null, serverName: 'Server Portal', isConfigured: false, requestUrl: 'https://yourdomain.com' });
+        res.json({ thumb: null, serverName: 'Server Portal', isConfigured: false, mediaServerType: 'plex', requestUrl: 'https://yourdomain.com' });
     }
 });
 
@@ -4118,7 +4608,7 @@ app.post('/api/status/config', requireAuth, requireAdmin, async (req, res) => {
             let normalizedUrl = '';
             if (service.url) {
                 try {
-                    normalizedUrl = normalizeExternalBaseUrl(service.url, { allowPrivate: ALLOW_PRIVATE_INTEGRATION_URLS, allowHttp: true });
+                    normalizedUrl = normalizeExternalBaseUrl(service.url, { allowPrivate: true, allowHttp: true });
                 } catch (e) {
                     return res.status(400).json({ error: `Invalid service URL for "${service.name || service.id || 'unknown'}": ${e.message}` });
                 }
@@ -4410,6 +4900,216 @@ app.get('/api/plex/dashboard', requireAuth, requireMember, async (req, res) => {
     } catch (e) {
         log(`Error fetching Plex dashboard: ${e.message}`);
         res.status(500).json({ error: 'Failed to fetch dashboard data' });
+    }
+});
+
+const jellyfinItemUrl = (config, itemId) => {
+    const baseUrl = String(config?.jellyfinUrl || '').replace(/\/+$/, '');
+    return baseUrl && itemId ? `${baseUrl}/web/#/details?id=${encodeURIComponent(itemId)}` : baseUrl;
+};
+
+const mapJellyfinItemForDiscover = (config, item = {}, type = '') => {
+    const id = item.Id || '';
+    const posterId = type === 'episode' && item.SeriesId ? item.SeriesId : id;
+    const title = type === 'episode'
+        ? (item.SeriesName ? `${item.SeriesName} - ${item.Name}` : item.Name)
+        : (item.Name || 'Untitled');
+    const tags = [];
+    const width = Number(item.Width || item.MediaStreams?.find?.((s) => s.Type === 'Video')?.Width || 0);
+    const height = Number(item.Height || item.MediaStreams?.find?.((s) => s.Type === 'Video')?.Height || 0);
+    if (width >= 3800 || height >= 2000) tags.push('4K');
+    else if (height >= 1000) tags.push('1080p');
+    else if (height >= 700) tags.push('720p');
+    const videoCodec = item.MediaStreams?.find?.((s) => s.Type === 'Video')?.Codec || item.MediaSources?.[0]?.VideoCodec;
+    if (videoCodec) tags.push(String(videoCodec).toUpperCase());
+
+    return {
+        ratingKey: id,
+        sourceRatingKey: id,
+        title,
+        parentTitle: item.Album || item.SeriesName || null,
+        type: item.Type,
+        year: item.ProductionYear,
+        thumb: posterId,
+        thumbUrl: posterId ? withBasePath(`/api/jellyfin/image?itemId=${encodeURIComponent(posterId)}&width=300&height=${type === 'music' ? 300 : 450}`) : '',
+        addedAt: item.DateCreated ? Date.parse(item.DateCreated) / 1000 : 0,
+        tags: [...new Set(tags)].slice(0, 4),
+        plexUrl: jellyfinItemUrl(config, id),
+    };
+};
+
+const fetchJellyfinItems = async (config, includeItemTypes, limit) => {
+    const baseUrl = resolveIntegrationUrlForFetch(config.jellyfinUrl);
+    const params = new URLSearchParams({
+        Recursive: 'true',
+        IncludeItemTypes: includeItemTypes,
+        SortBy: 'DateCreated',
+        SortOrder: 'Descending',
+        Limit: String(limit),
+        Fields: 'DateCreated,PrimaryImageAspectRatio,ProductionYear,SeriesName,Album,MediaSources,MediaStreams',
+        ImageTypeLimit: '1',
+        EnableImageTypes: 'Primary,Thumb,Backdrop',
+    });
+    const response = await fetchWithTimeout(`${baseUrl}/Items?${params.toString()}`, {
+        headers: jellyfinHeaders(config.jellyfinApiKey),
+    }, 15000);
+    if (!response.ok) throw new Error(`Jellyfin Items returned HTTP ${response.status}`);
+    const data = await response.json();
+    return Array.isArray(data.Items) ? data.Items : [];
+};
+
+app.get('/api/jellyfin/image', requireAuth, requireMember, async (req, res) => {
+    const itemId = String(req.query.itemId || '').trim();
+    const width = Math.min(Math.max(parseInt(req.query.width, 10) || 300, 64), 1200);
+    const height = Math.min(Math.max(parseInt(req.query.height, 10) || 450, 64), 1600);
+    if (!itemId || !/^[A-Za-z0-9_-]+$/.test(itemId)) return res.status(400).send('Invalid itemId');
+    try {
+        const config = await loadFile(CONFIG_PATH, {});
+        if (!isJellyfinConfigured(config)) return res.status(503).send('');
+        const baseUrl = resolveIntegrationUrlForFetch(config.jellyfinUrl);
+        const imageUrl = `${baseUrl}/Items/${encodeURIComponent(itemId)}/Images/Primary?fillWidth=${width}&fillHeight=${height}&quality=90`;
+        const response = await fetchWithTimeout(imageUrl, {
+            headers: jellyfinHeaders(config.jellyfinApiKey),
+        }, 15000);
+        if (!response.ok) throw new Error(`image HTTP ${response.status}`);
+        const buffer = Buffer.from(await response.arrayBuffer());
+        res.setHeader('Content-Type', response.headers.get('content-type') || 'image/jpeg');
+        res.setHeader('Cache-Control', 'public, max-age=86400');
+        res.send(buffer);
+    } catch (e) {
+        res.status(500).send('');
+    }
+});
+
+app.get('/api/jellyfin/user-image', requireAuth, requireMember, async (req, res) => {
+    const userId = String(req.query.userId || '').trim();
+    if (!userId || !/^[A-Za-z0-9_-]+$/.test(userId)) return res.status(400).send('Invalid userId');
+    try {
+        const config = await loadFile(CONFIG_PATH, {});
+        if (!isJellyfinConfigured(config)) return res.status(503).send('');
+        const baseUrl = resolveIntegrationUrlForFetch(config.jellyfinUrl);
+        const imageUrl = `${baseUrl}/Users/${encodeURIComponent(userId)}/Images/Primary?fillWidth=128&fillHeight=128&quality=90`;
+        const response = await fetchWithTimeout(imageUrl, {
+            headers: jellyfinHeaders(config.jellyfinApiKey),
+        }, 15000);
+        if (!response.ok) return res.status(404).send('');
+        const buffer = Buffer.from(await response.arrayBuffer());
+        res.setHeader('Content-Type', response.headers.get('content-type') || 'image/jpeg');
+        res.setHeader('Cache-Control', 'public, max-age=86400');
+        res.send(buffer);
+    } catch (e) {
+        res.status(500).send('');
+    }
+});
+
+const proxyJellyfinBrandingAsset = async (res, paths, fallbackContentType = 'image/png') => {
+    const config = await loadFile(CONFIG_PATH, {});
+    if (!isJellyfinConfigured(config)) return res.status(503).send('');
+    const baseUrl = resolveIntegrationUrlForFetch(config.jellyfinUrl);
+    for (const path of paths) {
+        const response = await fetchWithTimeout(`${baseUrl}${path}`, {
+            headers: jellyfinHeaders(config.jellyfinApiKey, { Accept: 'image/*,*/*;q=0.8' }),
+        }, 15000).catch(() => null);
+        if (!response || !response.ok) continue;
+        const buffer = Buffer.from(await response.arrayBuffer());
+        if (!buffer.length) continue;
+        res.setHeader('Content-Type', response.headers.get('content-type') || fallbackContentType);
+        res.setHeader('Cache-Control', 'public, max-age=3600');
+        return res.send(buffer);
+    }
+    return res.status(404).send('');
+};
+
+app.get('/api/jellyfin/branding/splash', publicReadRateLimit, async (req, res) => {
+    try {
+        await proxyJellyfinBrandingAsset(res, ['/Branding/Splashscreen'], 'image/jpeg');
+    } catch (e) {
+        res.status(500).send('');
+    }
+});
+
+app.get('/api/jellyfin/branding/icon', publicReadRateLimit, async (req, res) => {
+    try {
+        await proxyJellyfinBrandingAsset(res, ['/web/icon-transparent.png', '/web/assets/img/icon-transparent.png', '/web/favicon.ico'], 'image/png');
+    } catch (e) {
+        res.status(500).send('');
+    }
+});
+
+app.get('/api/jellyfin/branding/favicon', publicReadRateLimit, async (req, res) => {
+    try {
+        await proxyJellyfinBrandingAsset(res, ['/web/favicon.ico', '/web/icon-transparent.png', '/web/assets/img/icon-transparent.png'], 'image/x-icon');
+    } catch (e) {
+        res.status(500).send('');
+    }
+});
+
+app.get('/api/jellyfin/dashboard', requireAuth, requireMember, async (req, res) => {
+    try {
+        const config = await loadFile(CONFIG_PATH, {});
+        if (!isJellyfinConfigured(config)) {
+            return res.status(503).json({ error: 'Jellyfin not configured' });
+        }
+
+        const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 100, 1), 250);
+        const baseUrl = resolveIntegrationUrlForFetch(config.jellyfinUrl);
+        const [sessions, movies, episodes, music] = await Promise.all([
+            fetchWithTimeout(`${baseUrl}/Sessions`, { headers: jellyfinHeaders(config.jellyfinApiKey) }, 15000).then((r) => r.ok ? r.json() : []).catch(() => []),
+            fetchJellyfinItems(config, 'Movie', limit).catch((e) => { log(`Jellyfin movies fetch failed: ${e.message}`); return []; }),
+            fetchJellyfinItems(config, 'Episode', limit).catch((e) => { log(`Jellyfin episodes fetch failed: ${e.message}`); return []; }),
+            fetchJellyfinItems(config, 'MusicAlbum,Audio', limit).catch((e) => { log(`Jellyfin music fetch failed: ${e.message}`); return []; }),
+        ]);
+
+        const hideConfig = config.hideStreamUsers === true ? 'anonymous' : (config.hideStreamUsers || 'false');
+        const activeSessions = (Array.isArray(sessions) ? sessions : [])
+            .filter((session) => session.NowPlayingItem)
+            .map((session) => {
+                const item = session.NowPlayingItem || {};
+                const playState = session.PlayState || {};
+                const runtime = Number(item.RunTimeTicks || 0) / 10000;
+                const position = Number(playState.PositionTicks || 0) / 10000;
+                const streamBitrate = (Array.isArray(item.MediaStreams) ? item.MediaStreams : [])
+                    .filter((stream) => stream.Type === 'Video' || stream.Type === 'Audio')
+                    .reduce((total, stream) => total + Number(stream.BitRate || stream.Bitrate || 0), 0);
+                const mediaSourceBitrate = (Array.isArray(item.MediaSources) ? item.MediaSources : [])
+                    .reduce((max, source) => Math.max(max, Number(source.Bitrate || source.VideoBitrate || 0) + Number(source.AudioBitrate || 0)), 0);
+                const reportedBitrate = Number(session.TranscodingInfo?.Bitrate || item.Bitrate || streamBitrate || mediaSourceBitrate || 0);
+                const isHidden = !req.user.isAdmin && (hideConfig === 'anonymous' || hideConfig === 'hidden');
+                return {
+                    sessionId: session.Id,
+                    title: item.Name,
+                    type: item.Type,
+                    grandparentTitle: item.SeriesName || item.Album || null,
+                    year: item.ProductionYear,
+                    thumb: item.Id,
+                    thumbUrl: item.Id ? withBasePath(`/api/jellyfin/image?itemId=${encodeURIComponent(item.Id)}&width=300&height=450`) : '',
+                    user: (isHidden && hideConfig === 'hidden') ? null : (isHidden ? 'Anonymous' : (session.UserName || 'Unknown User')),
+                    userThumb: (!isHidden && session.UserId) ? withBasePath(`/api/jellyfin/user-image?userId=${encodeURIComponent(session.UserId)}`) : null,
+                    playerProduct: session.Client || 'Jellyfin',
+                    playerTitle: session.DeviceName || session.Client || 'Jellyfin Player',
+                    playerAddress: session.RemoteEndPoint || 'Unknown IP',
+                    sessionLocation: 'remote',
+                    state: playState.IsPaused ? 'paused' : 'playing',
+                    isTranscoding: !!session.TranscodingInfo,
+                    videoCodec: session.TranscodingInfo?.VideoCodec || null,
+                    audioCodec: session.TranscodingInfo?.AudioCodec || null,
+                    resolution: item.Height ? `${item.Height}p` : null,
+                    progress: runtime > 0 ? Math.min(100, Math.max(0, (position / runtime) * 100)) : 0,
+                    timeRemaining: Math.max(0, runtime - position),
+                    bandwidth: Math.round(reportedBitrate / 1000),
+                    plexUrl: jellyfinItemUrl(config, item.Id),
+                };
+            });
+
+        res.json({
+            activeSessions,
+            recentMovies: movies.map((item) => mapJellyfinItemForDiscover(config, item, 'movie')),
+            recentShows: episodes.map((item) => mapJellyfinItemForDiscover(config, item, 'episode')),
+            recentMusic: music.map((item) => mapJellyfinItemForDiscover(config, item, 'music')),
+        });
+    } catch (e) {
+        log(`Error fetching Jellyfin dashboard: ${e.message}`);
+        res.status(500).json({ error: 'Failed to fetch Jellyfin dashboard data' });
     }
 });
 
@@ -4867,6 +5567,86 @@ const calculateDelta = (current, previous) => {
 
 const sumLibraryPlays = (libraries = []) => (libraries || []).reduce((sum, lib) => sum + toNumber(lib.plays, 0), 0);
 
+const normalizeAnalyticsDaysForJellystat = (days) => {
+    if (String(days) === 'all') return 36500;
+    return Math.min(Math.max(parseInt(days, 10) || 30, 1), 36500);
+};
+
+const jellystatHeaders = (apiKey) => ({
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+    'X-API-Token': apiKey,
+});
+
+const fetchJellystatJson = async (config, endpoint, { method = 'GET', body = null, query = null } = {}) => {
+    if (!config?.jellystatUrl || !config?.jellystatApiKey) {
+        throw new Error('Jellystat is not configured');
+    }
+    const baseUrl = resolveIntegrationUrlForFetch(config.jellystatUrl);
+    const params = query ? `?${new URLSearchParams(query).toString()}` : '';
+    const response = await fetchWithTimeout(`${baseUrl}${endpoint}${params}`, {
+        method,
+        headers: jellystatHeaders(config.jellystatApiKey),
+        ...(body ? { body: JSON.stringify(body) } : {}),
+    }, 15000);
+    if (!response.ok) throw new Error(`Jellystat returned HTTP ${response.status} for ${endpoint}`);
+    return response.json().catch(() => null);
+};
+
+const sumJellystatRowCounts = (row = {}) => Object.entries(row)
+    .filter(([key]) => key !== 'Key')
+    .reduce((sum, [, value]) => sum + toNumber(value?.count, 0), 0);
+
+const buildJellystatLibraryHealth = (topLibraries = [], overview = [], metadata = [], libraryTypeTotals = {}) => {
+    const metadataById = new Map((Array.isArray(metadata) ? metadata : []).map((item) => [String(item.Id), item]));
+    const libraries = Array.isArray(overview) ? overview : [];
+    const totalCatalogBytes = libraries.reduce((sum, lib) => sum + toNumber(metadataById.get(String(lib.Id))?.Size, 0), 0);
+    const movies = libraries
+        .filter((lib) => String(lib.CollectionType || '').toLowerCase() === 'movies')
+        .reduce((sum, lib) => sum + toNumber(lib.Library_Count, 0), 0);
+    const shows = libraries
+        .filter((lib) => String(lib.CollectionType || '').toLowerCase() === 'tvshows')
+        .reduce((sum, lib) => sum + toNumber(lib.Library_Count, 0), 0);
+    const episodes = libraries.reduce((sum, lib) => sum + toNumber(lib.Episode_Count, 0), 0);
+    const libraryPlays = sumLibraryPlays(topLibraries);
+    const leadingLibraryPlays = toNumber(topLibraries?.[0]?.plays, 0);
+    const concentrationPct = libraryPlays > 0 ? Number(((leadingLibraryPlays / libraryPlays) * 100).toFixed(1)) : 0;
+    const activeLibraries = topLibraries.filter((lib) => toNumber(lib.plays, 0) > 0).length;
+    const watchedItemsEstimate = toNumber(libraryTypeTotals.Movie, 0) + toNumber(libraryTypeTotals.Series, 0) + toNumber(libraryTypeTotals.Audio, 0);
+    const totalPlayableItems = movies + episodes;
+    const catalogWatchedPct = totalPlayableItems > 0 ? Number(((watchedItemsEstimate / totalPlayableItems) * 100).toFixed(1)) : 0;
+    let healthLabel = 'Concentrated';
+    if (activeLibraries >= 5 && concentrationPct <= 55) healthLabel = 'Balanced';
+    if (activeLibraries >= 8 && concentrationPct <= 40) healthLabel = 'Excellent';
+
+    return {
+        activeLibraries,
+        concentrationPct,
+        totalCatalogItems: movies + shows,
+        totalCatalogBytes,
+        sizeGB: Number((totalCatalogBytes / (1024 * 1024 * 1024)).toFixed(1)),
+        fourKPercent: 0,
+        healthLabel,
+        catalogWatchedPct,
+        movies,
+        shows,
+        episodes,
+        artists: 0,
+        albums: 0,
+        tracks: 0,
+    };
+};
+
+const mapJellystatContent = (config, items = [], type = 'movie') => (Array.isArray(items) ? items : []).slice(0, 10).map((item) => ({
+    key: item.Id || item.Name,
+    title: item.Name || 'Untitled',
+    type,
+    thumb: item.Id || null,
+    thumbUrl: item.Id ? withBasePath(`/api/jellyfin/image?itemId=${encodeURIComponent(item.Id)}&width=300&height=450`) : '',
+    plays: toNumber(item.Plays ?? item.times_played ?? item.unique_viewers, 0),
+    plexUrl: jellyfinItemUrl(config, item.Id),
+}));
+
 const aggregateAnalyticsWindow = (historyItems, { afterTs = 0, beforeTs = null }, ctx, { includePortalUsers = false } = {}) => {
     const { accountsMap, sectionsMap, devicesMap, users, config } = ctx;
     const userCounts = {};
@@ -5014,6 +5794,116 @@ const summarizeLibraryHealth = (topLibraries = [], stats = {}, cachedData = {}) 
 };
 
 const getUniqueActiveViewers = (users = []) => (users || []).filter(u => toNumber(u.plays, 0) > 0).length;
+
+app.get('/api/jellystat/analytics', requireAuth, requireMember, async (req, res) => {
+    try {
+        const config = await loadFile(CONFIG_PATH, {});
+        if (!isJellyfinConfigured(config)) {
+            return res.status(503).json({ error: 'Jellyfin not configured' });
+        }
+        if (!config.jellystatUrl || !config.jellystatApiKey) {
+            return res.status(503).json({ error: 'Jellystat is not configured' });
+        }
+
+        const requestedDays = req.query.days || 30;
+        const days = normalizeAnalyticsDaysForJellystat(requestedDays);
+        const postBody = { days };
+        const [
+            libraryTypeTotals,
+            viewsByHour,
+            libraryOverview,
+            libraryMetadata,
+            mostViewedLibraries,
+            mostActiveUsers,
+            mostUsedClients,
+            mostViewedMovies,
+            mostViewedShows,
+            mostViewedMusic,
+            playbackMethods,
+        ] = await Promise.all([
+            fetchJellystatJson(config, '/stats/getViewsByLibraryType', { query: { days } }).catch((e) => { log(e.message); return {}; }),
+            fetchJellystatJson(config, '/stats/getViewsByHour', { query: { days } }).catch((e) => { log(e.message); return {}; }),
+            fetchJellystatJson(config, '/stats/getLibraryOverview', { query: { days } }).catch((e) => { log(e.message); return []; }),
+            fetchJellystatJson(config, '/stats/getLibraryMetadata').catch((e) => { log(e.message); return []; }),
+            fetchJellystatJson(config, '/stats/getMostViewedLibraries', { method: 'POST', body: postBody }).catch((e) => { log(e.message); return []; }),
+            fetchJellystatJson(config, '/stats/getMostActiveUsers', { method: 'POST', body: postBody }).catch((e) => { log(e.message); return []; }),
+            fetchJellystatJson(config, '/stats/getMostUsedClient', { method: 'POST', body: postBody }).catch((e) => { log(e.message); return []; }),
+            fetchJellystatJson(config, '/stats/getMostViewedByType', { method: 'POST', body: { ...postBody, type: 'Movie' } }).catch((e) => { log(e.message); return []; }),
+            fetchJellystatJson(config, '/stats/getMostViewedByType', { method: 'POST', body: { ...postBody, type: 'Series' } }).catch((e) => { log(e.message); return []; }),
+            fetchJellystatJson(config, '/stats/getMostViewedByType', { method: 'POST', body: { ...postBody, type: 'Audio' } }).catch((e) => { log(e.message); return []; }),
+            fetchJellystatJson(config, '/stats/getPlaybackMethodStats', { method: 'POST', body: postBody }).catch((e) => { log(e.message); return []; }),
+        ]);
+
+        const peakHours = new Array(24).fill(0);
+        if (Array.isArray(viewsByHour?.stats)) {
+            viewsByHour.stats.forEach((row) => {
+                const hour = parseInt(row.Key, 10);
+                if (hour >= 0 && hour < 24) peakHours[hour] = sumJellystatRowCounts(row);
+            });
+        }
+
+        const shouldObfuscateUsernames = !req.user?.isAdmin;
+        const topUsers = (Array.isArray(mostActiveUsers) ? mostActiveUsers : []).map((user, index) => ({
+            id: user.UserId || user.Id || user.Name || `user-${index}`,
+            username: shouldObfuscateUsernames ? `Viewer ${index + 1}` : (user.Name || user.UserName || `User ${index + 1}`),
+            thumb: user.UserId ? withBasePath(`/api/jellyfin/user-image?userId=${encodeURIComponent(user.UserId)}`) : null,
+            plays: toNumber(user.Plays ?? user.TotalPlays, 0),
+        }));
+
+        const topLibraries = (Array.isArray(mostViewedLibraries) ? mostViewedLibraries : []).map((library, index) => ({
+            id: library.Id || library.Name || `library-${index}`,
+            title: library.Name || `Library ${index + 1}`,
+            plays: toNumber(library.Plays ?? library.Count, 0),
+        })).sort((a, b) => b.plays - a.plays).slice(0, 10);
+
+        const topDevices = (Array.isArray(mostUsedClients) ? mostUsedClients : []).map((device, index) => ({
+            name: device.Client || device.Name || `Client ${index + 1}`,
+            plays: toNumber(device.Plays ?? device.Count, 0),
+        })).sort((a, b) => b.plays - a.plays).slice(0, 10);
+
+        const playbackCounts = {};
+        (Array.isArray(playbackMethods) ? playbackMethods : []).forEach((method) => {
+            playbackCounts[String(method.Name || '').toLowerCase()] = Math.max(playbackCounts[String(method.Name || '').toLowerCase()] || 0, toNumber(method.Count, 0));
+        });
+
+        const totalPlaybacks = sumLibraryPlays(topLibraries) || Object.values(libraryTypeTotals || {}).reduce((sum, value) => sum + toNumber(value, 0), 0);
+        const libraryHealth = buildJellystatLibraryHealth(topLibraries, libraryOverview, libraryMetadata, libraryTypeTotals);
+
+        res.json({
+            topUsers,
+            topLibraries,
+            topMovies: mapJellystatContent(config, mostViewedMovies, 'movie'),
+            topShows: mapJellystatContent(config, mostViewedShows, 'show'),
+            topMusic: mapJellystatContent(config, mostViewedMusic, 'track'),
+            topDevices,
+            peakHours,
+            totalPlaybacks,
+            maxConcurrentStreams: 0,
+            maxDirectPlays: toNumber(playbackCounts.directplay, 0),
+            maxTranscodes: toNumber(playbackCounts.transcode, 0),
+            compare: null,
+            libraryHealth,
+            requestedPeriodDays: requestedDays,
+            cachePeriodDays: requestedDays,
+            cacheFallback: false,
+            source: 'jellystat',
+            jellystatInsights: {
+                streamsRecord: 0,
+                transcodeRecord: toNumber(playbackCounts.transcode, 0),
+                directPlayRecord: toNumber(playbackCounts.directplay, 0),
+                directStreamRecord: toNumber(playbackCounts.directstream, 0),
+                totalPlays: totalPlaybacks,
+                tvPlays: toNumber(libraryTypeTotals.Series, 0),
+                moviePlays: toNumber(libraryTypeTotals.Movie, 0),
+                musicPlays: toNumber(libraryTypeTotals.Audio, 0),
+                totalTimeStr: '',
+            },
+        });
+    } catch (e) {
+        log(`Jellystat analytics error: ${e.message}`);
+        res.status(500).json({ error: 'Failed to fetch Jellystat analytics' });
+    }
+});
 
 const fetchPlexAccountHistory = async (uri, config, accountID, { maxItems = 250000 } = {}) => {
     const pageSize = 5000;
@@ -6110,6 +7000,14 @@ async function loadStatusState() {
         const configData = await fs.readFile(STATUS_CONFIG_PATH, 'utf-8');
         statusConfig = JSON.parse(configData);
     } catch (e) {
+        const appConfig = await loadFile(CONFIG_PATH, {});
+        statusConfig = createDefaultStatusConfig(appConfig);
+        await saveFile(STATUS_CONFIG_PATH, statusConfig);
+    }
+
+    if (!Array.isArray(statusConfig.services) || statusConfig.services.length === 0) {
+        const appConfig = await loadFile(CONFIG_PATH, {});
+        statusConfig = createDefaultStatusConfig(appConfig);
         await saveFile(STATUS_CONFIG_PATH, statusConfig);
     }
 
@@ -6134,7 +7032,7 @@ function performSingleProbe(service) {
 
         let targetUrl = rawUrl;
         try {
-            targetUrl = normalizeExternalBaseUrl(rawUrl, { allowPrivate: ALLOW_PRIVATE_INTEGRATION_URLS, allowHttp: true });
+            targetUrl = normalizeExternalBaseUrl(rawUrl, { allowPrivate: true, allowHttp: true });
         } catch (e) {
             return resolve({ status: 'offline', latency: 0, httpCode: 0 });
         }
@@ -7412,7 +8310,7 @@ const fetchRequestIndex = async (config) => {
     const headers = { Accept: 'application/json', 'Content-Type': 'application/json', 'X-Api-Key': apiKey };
     const items = [];
 
-    if (requestAppType === 'overseerr' || requestAppType === 'jellyseerr') {
+    if (requestAppType === 'seerr' || requestAppType === 'overseerr' || requestAppType === 'jellyseerr') {
         let page = 1;
         let totalPages = 1;
         while (page <= totalPages && page <= 20) {

--- a/input.css
+++ b/input.css
@@ -4,8 +4,8 @@
 
 @layer base {
   :root {
-    --color-plex: 229 160 13;
-    --color-plex-hover: 240 168 16;
+    --color-plex: 247 198 0;
+    --color-plex-hover: 248 208 46;
   }
   body {
     @apply bg-background text-text font-sans antialiased;
@@ -83,18 +83,18 @@
   /* —— Buttons —— */
   .btn-primary {
     @apply inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl font-bold text-sm;
-    @apply bg-gradient-to-r from-plex to-amber-500 text-background;
+    @apply bg-gradient-to-r from-plex to-plex-hover text-background;
     @apply hover:brightness-110 active:scale-[0.98] transition-all;
     @apply disabled:opacity-50 disabled:pointer-events-none;
-    box-shadow: 0 8px 28px rgba(229, 160, 13, 0.35);
+    box-shadow: 0 8px 28px rgb(var(--color-plex) / 0.35);
   }
 
   .btn-primary-lg {
     @apply inline-flex items-center justify-center gap-2 w-full px-8 py-4 rounded-xl font-bold text-base;
-    @apply bg-gradient-to-r from-plex to-amber-500 text-background;
+    @apply bg-gradient-to-r from-plex to-plex-hover text-background;
     @apply hover:brightness-110 active:scale-[0.98] transition-all;
     @apply disabled:opacity-50 disabled:pointer-events-none;
-    box-shadow: 0 8px 28px rgba(229, 160, 13, 0.35);
+    box-shadow: 0 8px 28px rgb(var(--color-plex) / 0.35);
   }
 
   .btn-secondary {
@@ -126,11 +126,12 @@
   }
 
   .page-title {
-    @apply text-xl md:text-3xl font-black tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-plex to-amber-400;
+    @apply text-xl md:text-3xl font-black tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-plex to-plex-hover;
   }
 
   .nav-item-active {
-    @apply bg-plex/15 text-plex shadow-[0_0_15px_rgba(229,160,13,0.1)];
+    @apply bg-plex/15 text-plex;
+    box-shadow: 0 0 15px rgb(var(--color-plex) / 0.1);
   }
 
   .nav-shell {

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -555,8 +555,8 @@ video {
 }
 
 :root {
-  --color-plex: 229 160 13;
-  --color-plex-hover: 240 168 16;
+  --color-plex: 247 198 0;
+  --color-plex-hover: 248 208 46;
 }
 
 body {
@@ -669,7 +669,7 @@ input[type="date"], input[type="time"], input[type="datetime-local"], input[type
   --tw-gradient-from: rgb(var(--color-plex) / 1) var(--tw-gradient-from-position);
   --tw-gradient-to: rgb(var(--color-plex) / 0) var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
-  --tw-gradient-to: #f59e0b var(--tw-gradient-to-position);
+  --tw-gradient-to: rgb(var(--color-plex-hover) / 1) var(--tw-gradient-to-position);
   --tw-text-opacity: 1;
   color: rgb(13 17 23 / var(--tw-text-opacity, 1));
   transition-property: all;
@@ -694,7 +694,7 @@ input[type="date"], input[type="time"], input[type="datetime-local"], input[type
 }
 
 .btn-primary {
-  box-shadow: 0 8px 28px rgba(229, 160, 13, 0.35);
+  box-shadow: 0 8px 28px rgb(var(--color-plex) / 0.35);
 }
 
 .btn-primary-lg {
@@ -715,7 +715,7 @@ input[type="date"], input[type="time"], input[type="datetime-local"], input[type
   --tw-gradient-from: rgb(var(--color-plex) / 1) var(--tw-gradient-from-position);
   --tw-gradient-to: rgb(var(--color-plex) / 0) var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
-  --tw-gradient-to: #f59e0b var(--tw-gradient-to-position);
+  --tw-gradient-to: rgb(var(--color-plex-hover) / 1) var(--tw-gradient-to-position);
   --tw-text-opacity: 1;
   color: rgb(13 17 23 / var(--tw-text-opacity, 1));
   transition-property: all;
@@ -740,7 +740,7 @@ input[type="date"], input[type="time"], input[type="datetime-local"], input[type
 }
 
 .btn-primary-lg {
-  box-shadow: 0 8px 28px rgba(229, 160, 13, 0.35);
+  box-shadow: 0 8px 28px rgb(var(--color-plex) / 0.35);
 }
 
 .btn-secondary {
@@ -875,7 +875,7 @@ input[type="date"], input[type="time"], input[type="datetime-local"], input[type
   --tw-gradient-from: rgb(var(--color-plex) / 1) var(--tw-gradient-from-position);
   --tw-gradient-to: rgb(var(--color-plex) / 0) var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
-  --tw-gradient-to: #fbbf24 var(--tw-gradient-to-position);
+  --tw-gradient-to: rgb(var(--color-plex-hover) / 1) var(--tw-gradient-to-position);
   -webkit-background-clip: text;
           background-clip: text;
   font-size: 1.25rem;
@@ -896,9 +896,7 @@ input[type="date"], input[type="time"], input[type="datetime-local"], input[type
   background-color: rgb(var(--color-plex) / 0.15);
   --tw-text-opacity: 1;
   color: rgb(var(--color-plex) / var(--tw-text-opacity, 1));
-  --tw-shadow: 0 0 15px rgba(229,160,13,0.1);
-  --tw-shadow-colored: 0 0 15px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  box-shadow: 0 0 15px rgb(var(--color-plex) / 0.1);
 }
 
 .nav-shell {
@@ -2972,10 +2970,6 @@ input[type="date"], input[type="time"], input[type="datetime-local"], input[type
   background-color: rgb(245 158 11 / 0.15);
 }
 
-.bg-amber-500\/\[0\.04\] {
-  background-color: rgb(245 158 11 / 0.04);
-}
-
 .bg-background {
   --tw-bg-opacity: 1;
   background-color: rgb(13 17 23 / var(--tw-bg-opacity, 1));
@@ -3178,6 +3172,10 @@ input[type="date"], input[type="time"], input[type="datetime-local"], input[type
   background-color: rgb(var(--color-plex) / 0.03);
 }
 
+.bg-plex\/\[0\.04\] {
+  background-color: rgb(var(--color-plex) / 0.04);
+}
+
 .bg-plex\/\[0\.06\] {
   background-color: rgb(var(--color-plex) / 0.06);
 }
@@ -3301,14 +3299,6 @@ input[type="date"], input[type="time"], input[type="datetime-local"], input[type
 
 .bg-\[linear-gradient\(45deg\2c rgba\(255\2c 255\2c 255\2c 0\.15\)_25\%\2c transparent_25\%\2c transparent_50\%\2c rgba\(255\2c 255\2c 255\2c 0\.15\)_50\%\2c rgba\(255\2c 255\2c 255\2c 0\.15\)_75\%\2c transparent_75\%\2c transparent\)\] {
   background-image: linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);
-}
-
-.bg-\[radial-gradient\(ellipse_70\%_40\%_at_50\%_0\%\2c rgba\(229\2c 160\2c 13\2c 0\.06\)\2c transparent\)\] {
-  background-image: radial-gradient(ellipse 70% 40% at 50% 0%,rgba(229,160,13,0.06),transparent);
-}
-
-.bg-\[radial-gradient\(ellipse_80\%_50\%_at_50\%_-20\%\2c rgba\(229\2c 160\2c 13\2c 0\.12\)\2c transparent\)\] {
-  background-image: radial-gradient(ellipse 80% 50% at 50% -20%,rgba(229,160,13,0.12),transparent);
 }
 
 .bg-gradient-to-b {
@@ -3472,6 +3462,11 @@ input[type="date"], input[type="time"], input[type="datetime-local"], input[type
   --tw-gradient-stops: var(--tw-gradient-from), rgb(var(--color-plex) / 1) var(--tw-gradient-via-position), var(--tw-gradient-to);
 }
 
+.via-plex-hover {
+  --tw-gradient-to: rgb(var(--color-plex-hover) / 0)  var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), rgb(var(--color-plex-hover) / 1) var(--tw-gradient-via-position), var(--tw-gradient-to);
+}
+
 .via-plex\/10 {
   --tw-gradient-to: rgb(var(--color-plex) / 0)  var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), rgb(var(--color-plex) / 0.1) var(--tw-gradient-via-position), var(--tw-gradient-to);
@@ -3525,6 +3520,10 @@ input[type="date"], input[type="time"], input[type="datetime-local"], input[type
 
 .to-plex {
   --tw-gradient-to: rgb(var(--color-plex) / 1) var(--tw-gradient-to-position);
+}
+
+.to-plex-hover {
+  --tw-gradient-to: rgb(var(--color-plex-hover) / 1) var(--tw-gradient-to-position);
 }
 
 .to-plex\/0 {
@@ -4554,12 +4553,6 @@ input[type="date"], input[type="time"], input[type="datetime-local"], input[type
 
 .shadow-\[0_0_12px_rgba\(229\2c 160\2c 13\2c 0\.2\)\] {
   --tw-shadow: 0 0 12px rgba(229,160,13,0.2);
-  --tw-shadow-colored: 0 0 12px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-}
-
-.shadow-\[0_0_12px_rgba\(229\2c 160\2c 13\2c 0\.5\)\] {
-  --tw-shadow: 0 0 12px rgba(229,160,13,0.5);
   --tw-shadow-colored: 0 0 12px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }


### PR DESCRIPTION
Server Manager Portal has been Plex-only up to now — this PR brings Jellyfin in as a full first-class option, not a bolt-on. You can now pick Plex or Jellyfin as your media player, and pretty much everything downstream (login, dashboard, discover, users, analytics, diagnostics, background tasks) adapts to whichever one you're running.

Plex users won't notice any difference. Nothing about the existing Plex OAuth flow, token/server selection, Tautulli, Plex stats cache, or Plex diagnostics has changed — it was all left alone on purpose.

---

## What's in here

### Media player selection
You can now choose Plex or Jellyfin as your media player. The settings tab that used to say "Plex Integration" is now just "Media Player" — but the old `plex` route/tab ID is still there under the hood, so any bookmarked links like `/settings#plex` still work fine.

All the existing Plex stuff (OAuth login, token/server selection, direct URL, Tautulli, stats cache, diagnostics) is untouched. On the Jellyfin side, there's a new config section for server URL, API key, connection testing, and a setup flow tailored to Jellyfin.

### Jellyfin auth
Login works two ways: normal username/password, or Quick Connect for one-click sign-in. Quick Connect polling got its own rate limiter so it doesn't get caught by the generic auth callback limit anymore, and I slowed the poll interval from 3s to 5s since 3 was more aggressive than it needed to be.

Also added: admin detection based on Jellyfin's user policy, proper session handling with avatars, and a login button that picks up the server's branding/icon.

### Branding
This was the fiddly part. Jellyfin can now feed its icon, favicon, and splash screen straight into the portal through a few new proxy endpoints:

- `GET /api/jellyfin/branding/icon`
- `GET /api/jellyfin/branding/favicon`
- `GET /api/jellyfin/branding/splash`

There's also a proper settings section for server logo URL, splash background, a branding preset, and a live preview so you're not guessing what it'll look like. Along the way I fixed the splash image tiling instead of filling the screen (that one was annoying to track down), got rid of the circular blue chrome around custom logos so they don't look squashed, and made sure the big splash background only shows up on public/login pages — didn't want it swallowing the admin screens.

### Discover & dashboard
Jellyfin now has its own recently-added rows for movies, shows/episodes, and music, plus live activity and stream bandwidth/direct-play info. The Discover page used to just say "Plex not configured" if you weren't on Plex — that's gone now, replaced with proper Jellyfin empty/connected states. Also fixed episode posters so they use the show's artwork instead of looking wrong.

### Users
User sync and profile picture import now work for Jellyfin, and the user management screen shows Jellyfin-appropriate wording and active/revoked states instead of Plex-flavored copy. Cleanup and revoke messaging was changed to "portal access" in the places where it applies to either platform.

### Jellystat integration
Added Jellystat as the analytics companion for Jellyfin, the same way Tautulli has always served Plex — config fields, an icon, its own analytics endpoint, and activity widgets on the home dashboard. The analytics page now switches between the two automatically depending on what you're running, and Plex/Tautulli-only graphs are hidden when they don't apply.

### Media stack settings
Reorganized this page into clearer sections (Sonarr/Radarr, request apps, analytics/status companions) since it was getting a bit cluttered. Also renamed the Overseerr-style label to **Seerr**, and added Jellyseerr support plus selfh.st icons throughout. Plex mode still shows Tautulli, Jellyfin mode shows Jellystat.

### System diagnostics
Diagnostics now knows which media player you're on (`mediaServerType`, `jellyfinConfigured`) and adjusts what it expects accordingly — Jellyfin mode won't ding your health score for missing a Plex stats cache, for example. The existing upstream maintenance checks are still intact, just layered with the new logic.

### Background tasks
The task list adapts too. On Jellyfin, "Sync Plex Users" becomes "Sync Jellyfin Users" with matching description, the Plex Stats Builder task is hidden since it doesn't apply, and revoke/cleanup wording uses portal/Jellyfin language. Plex mode is untouched. The diagnostics job list pulls from the same underlying task data now, so the two stay in sync.

### Home dashboard
Jellyfin portals no longer get stuck on a Plex-only placeholder — they get their own library cards and a Jellystat-backed activity summary instead. Fixed avatar/profile resolution for Jellyfin sessions, and double-checked that admin quick actions still show up properly either way.

### Status monitor
Added default monitor entries for Server Portal, Jellyfin, Jellystat, Sonarr, Radarr, and Seerr, and confirmed `/api/status` reports correctly across the board.

### Login page
Supports both Plex and Jellyfin now, with Quick Connect, server icon, and splash branding baked into the Jellyfin flow. Fixed custom logos getting cropped into an ugly blue circle. Plex's temporary access flow is untouched.

### README
Updated it to reflect Plex/Jellyfin support rather than Plex-only, added a Jellyfin badge, and documented the new auth flow, branding proxy behavior, and background task differences. Also swapped the reverse-proxy examples to a neutral `media.example.com`, updated the config table, and fixed a broken JWT secret command that had bad quoting.

---

## API / backend changes

**New endpoints**
- `GET /api/jellyfin/branding/icon`
- `GET /api/jellyfin/branding/favicon`
- `GET /api/jellyfin/branding/splash`
- `GET /api/jellyfin/image`
- `GET /api/jellyfin/user-image`
- `GET /api/jellyfin/dashboard`
- `GET /api/jellystat/analytics`

**Changed**
- `GET /api/tasks` returns media-aware labels/descriptions now
- Public config includes media player, logo, splash, and branding data

**Auth** — Jellyfin password auth plus the full Quick Connect flow (initiate/poll/token exchange), with its own rate limiter so it can't interfere with regular auth. Plex OAuth wasn't touched.

**Diagnostics** — Jellyfin-aware detection and health expectations layered in; Plex behavior stayed exactly as it was.

---

## Frontend changes
- **Settings** — Media Player relabel, new Jellyfin config, branding UI, reorganized Media Stack, Jellystat/Jellyseerr/Seerr support, media-aware diagnostics and background tasks
- **Login** — Quick Connect, server logo, splash screen
- **Navigation** — configured server icon takes priority over the old fallback, no more blue circular logo chrome
- **Home / Discover / Analytics** — all Jellyfin/Jellystat-aware now, with proper artwork, profile images, and empty/connected states

---