### PR TITLE
feat(i18n): localize Wrap-Up and notifications

### DIFF
--- a/client/discovery/DiscoverAchievementsTeaser.tsx
+++ b/client/discovery/DiscoverAchievementsTeaser.tsx
@@ -99,9 +99,9 @@ export const DiscoverAchievementsTeaser: React.FC<{
                         <Trophy className="w-3.5 h-3.5 text-plex shrink-0" />
                         <span className="truncate">
                             {t(pinned ? 'hero.achievementsPinned' : 'hero.achievementsNext', {
-                                name: next.name || 'badge',
+                                name: next.name || t('hero.achievementFallbackBadge'),
                                 progress: next.earned
-                                    ? 'earned'
+                                    ? t('hero.achievementProgressEarned')
                                     : `${next.progress ?? 0}/${next.threshold ?? 0}`,
                             })}
                         </span>

--- a/client/discovery/i18n/en.ts
+++ b/client/discovery/i18n/en.ts
@@ -183,6 +183,13 @@ export const en = {
         chipFreshTv: 'New Series',
         achievementsNext: 'Next unlock: {name} ({progress})',
         achievementsPinned: 'Pinned: {name} ({progress})',
+        achievementFallbackBadge: 'badge',
+        achievementProgressEarned: 'earned',
+    },
+    notifications: {
+        title: 'Notifications',
+        markAllRead: 'Mark all read',
+        empty: 'No notifications yet',
     },
     home: {
         forYou: 'For you',

--- a/client/discovery/i18n/fr.ts
+++ b/client/discovery/i18n/fr.ts
@@ -122,6 +122,9 @@ export const fr: DeepPartial<EnCatalog> = {
         totalXp: 'XP totale',
         periodXp: 'XP de la période',
         periodXpSub: 'Sur la plage sélectionnée',
+        periodXpVsPrior: '{delta} par rapport à la période précédente',
+        periodBadges: 'Badges sur cette période',
+        periodBadgesSub: 'Débloqués sur la plage sélectionnée',
         xpToNext: 'XP jusqu’au prochain niveau',
         badges: 'Badges',
         latestBadge: 'Dernier badge',
@@ -182,6 +185,13 @@ export const fr: DeepPartial<EnCatalog> = {
         chipFreshTv: 'Nouvelles séries',
         achievementsNext: 'Prochain déblocage : {name} ({progress})',
         achievementsPinned: 'Épinglé : {name} ({progress})',
+        achievementFallbackBadge: 'badge',
+        achievementProgressEarned: 'obtenu',
+    },
+    notifications: {
+        title: 'Notifications',
+        markAllRead: 'Tout marquer comme lu',
+        empty: 'Aucune notification pour le moment',
     },
     home: {
         forYou: 'Pour vous',

--- a/client/shared/InAppNotificationsBell.tsx
+++ b/client/shared/InAppNotificationsBell.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Bell } from 'lucide-react';
 import { apiFetch } from './api';
+import { useDiscoverI18n } from '../discovery/i18n';
+import type { DiscoverTranslate } from '../discovery/i18n/types';
 
 export type InAppNotification = {
     id: string;
@@ -12,17 +14,17 @@ export type InAppNotification = {
     createdAt?: string;
 };
 
-const formatRelative = (iso?: string) => {
+const formatRelative = (iso: string | undefined, t: DiscoverTranslate) => {
     if (!iso) return '';
     const ms = Date.now() - new Date(iso).getTime();
     if (!Number.isFinite(ms) || ms < 0) return '';
     const mins = Math.floor(ms / 60000);
-    if (mins < 1) return 'just now';
-    if (mins < 60) return `${mins}m`;
+    if (mins < 1) return t('common.justNow');
+    if (mins < 60) return t('common.minutesAgo', { count: mins });
     const hours = Math.floor(mins / 60);
-    if (hours < 48) return `${hours}h`;
+    if (hours < 48) return t('common.hoursAgo', { count: hours });
     const days = Math.floor(hours / 24);
-    return `${days}d`;
+    return t('common.daysAgo', { count: days });
 };
 
 type Props = {
@@ -39,6 +41,7 @@ export const InAppNotificationsBell: React.FC<Props> = ({
     buttonClassName = '',
     placement = 'down',
 }) => {
+    const { t } = useDiscoverI18n();
     const [open, setOpen] = useState(false);
     const [items, setItems] = useState<InAppNotification[]>([]);
     const [unread, setUnread] = useState(0);
@@ -123,8 +126,8 @@ export const InAppNotificationsBell: React.FC<Props> = ({
                     if (!open) refresh();
                 }}
                 className={buttonClassName || 'relative text-muted hover:text-text transition-colors'}
-                title="Notifications"
-                aria-label="Notifications"
+                title={t('notifications.title')}
+                aria-label={t('notifications.title')}
                 aria-expanded={open}
             >
                 <Bell className="w-4 h-4" />
@@ -141,22 +144,22 @@ export const InAppNotificationsBell: React.FC<Props> = ({
                     }`}
                 >
                     <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-border/80">
-                        <p className="text-xs font-bold uppercase tracking-wider text-muted">Notifications</p>
+                        <p className="text-xs font-bold uppercase tracking-wider text-muted">{t('notifications.title')}</p>
                         {unread > 0 && (
                             <button
                                 type="button"
                                 onClick={markAllRead}
                                 className="text-[11px] font-semibold text-plex hover:underline"
                             >
-                                Mark all read
+                                {t('notifications.markAllRead')}
                             </button>
                         )}
                     </div>
                     <div className="overflow-y-auto max-h-[20rem] custom-scrollbar">
                         {loading && !items.length ? (
-                            <p className="px-3 py-6 text-sm text-muted text-center">Loading…</p>
+                            <p className="px-3 py-6 text-sm text-muted text-center">{t('common.loadingMore')}</p>
                         ) : !items.length ? (
-                            <p className="px-3 py-6 text-sm text-muted text-center">No notifications yet</p>
+                            <p className="px-3 py-6 text-sm text-muted text-center">{t('notifications.empty')}</p>
                         ) : (
                             items.map((item) => (
                                 <button
@@ -174,7 +177,7 @@ export const InAppNotificationsBell: React.FC<Props> = ({
                                             {item.body ? (
                                                 <p className="text-xs text-muted mt-0.5 line-clamp-2">{item.body}</p>
                                             ) : null}
-                                            <p className="text-[10px] text-muted/80 mt-1">{formatRelative(item.createdAt)}</p>
+                                            <p className="text-[10px] text-muted/80 mt-1">{formatRelative(item.createdAt, t)}</p>
                                         </div>
                                     </div>
                                 </button>


### PR DESCRIPTION
This PR continues the French localization work from #93 with a small, focused follow-up based on the current Nightly branch.

Changes include:
- Completed the 3 missing French Wrap-Up translation keys
- Localized Discover Achievements teaser fallback text
- Localized the in-app notification bell UI chrome
- Reused existing relative-time and loading translation keys where possible
- Kept backend/API-provided notification titles and bodies untouched

Verification:
- English keys: 551
- French keys: 551
- Missing French keys: 0
- Extra French keys: 0
- Placeholder mismatches: 0
- `npm run build:js` passes successfully

The existing duplicate-key warnings in `client/poster-sets/usePosterSetsDashboard.ts` are unrelated to these changes.

I deliberately left the new Achievements-specific localization system untouched for now, since Nightly introduced `client/achievements/i18n.ts` and I don't want to change that architecture without maintainer direction.