### PR TITLE
Fix Achievements i18n locale reactivity

### DIFF
--- a/client/achievements/AchievementsAnalyticsLeaderboard.tsx
+++ b/client/achievements/AchievementsAnalyticsLeaderboard.tsx
@@ -7,7 +7,7 @@ import {
 } from 'recharts';
 import { apiFetch } from '../shared/api';
 import { logoUrl } from '../shared/basePath';
-import { tAchievements } from './i18n';
+import { tAchievements, useAchievementsI18n } from './i18n';
 
 type LeaderboardEntry = {
     rank: number;
@@ -40,6 +40,7 @@ export const AchievementsAnalyticsLeaderboard: React.FC<Props> = ({
     isAdmin,
     onUserClick,
 }) => {
+    const { locale, tAchievements } = useAchievementsI18n();
     const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
     const [loading, setLoading] = useState(true);
     const [enabled, setEnabled] = useState(true);
@@ -116,7 +117,7 @@ export const AchievementsAnalyticsLeaderboard: React.FC<Props> = ({
                 sub: topLevel ? tAchievements('common.badgeCount', { count: topLevel.earnedCount }) : '',
             },
         ];
-    }, [byXp, byBadges, byLevel]);
+    }, [byXp, byBadges, byLevel, locale]);
 
     const xpChart = useMemo(
         () => byXp.slice(0, 10).map((u) => ({ name: shortName(u.username), full: u.username, value: u.xp })),

--- a/client/achievements/AchievementsDashboard.tsx
+++ b/client/achievements/AchievementsDashboard.tsx
@@ -10,7 +10,7 @@ import { logoUrl, portalUrl, resolvePortalAssetUrl } from '../shared/basePath';
 import { ModalPortal } from '../shared/ModalPortal';
 import { ToastContainer, pushToast, type ToastMessage } from '../shared/toast';
 import { ShareAchievementsModal } from '../shared/ShareAchievements';
-import { tAchievements } from './i18n';
+import { tAchievements, useAchievementsI18n } from './i18n';
 import { groupBadgesIntoFamilies, type BadgeFamily } from './badgeFamilies';
 import { BadgeDetailDrawer } from './BadgeDetailDrawer';
 import { UnlockCelebration } from './UnlockCelebration';
@@ -33,8 +33,8 @@ const BREAKDOWN_META: Record<string, { icon: LucideIcon; statKey?: string; tipKe
     hoursWatched: { icon: Clock, tipKey: 'xp.tip.hoursWatched', statKey: 'hoursWatched' },
 };
 
-const formatLabel = (key: string) => tAchievements(`xp.source.${key}`) !== `xp.source.${key}`
-    ? tAchievements(`xp.source.${key}`)
+const formatLabel = (key: string, translate = tAchievements) => translate(`xp.source.${key}`) !== `xp.source.${key}`
+    ? translate(`xp.source.${key}`)
     : key.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase());
 
 const resolveLeaderboardAvatar = (thumb: string | null | undefined, width = 64, height = 64) => {
@@ -57,6 +57,7 @@ export const BadgeTile: React.FC<{
     compact?: boolean;
     onClick?: () => void;
 }> = ({ badge, compact, onClick }) => {
+    const { tAchievements } = useAchievementsI18n();
     const earned = !!badge?.earned;
     return (
         <button
@@ -95,6 +96,7 @@ export const LadderFamilyCard: React.FC<{
     onToggle: () => void;
     onBadgeClick?: (badge: any) => void;
 }> = ({ family, expanded, onToggle, onBadgeClick }) => {
+    const { tAchievements } = useAchievementsI18n();
     const focus = family.focus;
     const next = family.next;
     const complete = family.earnedCount >= family.totalCount && family.totalCount > 0;
@@ -171,6 +173,7 @@ export const ProfileBadgeRack: React.FC<{
     onOpenAll?: () => void;
     max?: number;
 }> = ({ earned, level, xp, onOpenAll, max = 12 }) => {
+    const { tAchievements } = useAchievementsI18n();
     const shown = (earned || []).slice(0, max);
     if (!shown.length && level == null) return null;
     return (
@@ -237,6 +240,7 @@ export const XpBreakdownModal: React.FC<{
     totalBadges = 0,
     nextUnlocks = [],
 }) => {
+    const { tAchievements } = useAchievementsI18n();
     if (!open) return null;
 
     const level = Number(levelProgress?.level) || 1;
@@ -323,7 +327,7 @@ export const XpBreakdownModal: React.FC<{
                                     {topKey && (
                                         <p className="text-xs text-muted mt-2">
                                             {tAchievements('xp.topSource', {
-                                                source: formatLabel(topKey),
+                                                source: formatLabel(topKey, tAchievements),
                                                 pct: topShare,
                                             })}
                                         </p>
@@ -423,7 +427,7 @@ export const XpBreakdownModal: React.FC<{
                                                     <div className="flex items-start justify-between gap-3">
                                                         <div className="min-w-0">
                                                             <p className="text-sm font-bold text-text truncate">
-                                                                {formatLabel(key)}
+                                                                {formatLabel(key, tAchievements)}
                                                             </p>
                                                             <p className="text-[11px] text-muted mt-0.5 line-clamp-2">
                                                                 {tAchievements(meta.tipKey)}
@@ -470,7 +474,7 @@ export const XpBreakdownModal: React.FC<{
                                     <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-1.5">
                                         {zeroRows.map(([key]) => (
                                             <div key={key} className="flex items-center justify-between gap-2 rounded-lg border border-white/5 bg-black/15 px-3 py-2 text-xs">
-                                                <span className="text-muted truncate">{formatLabel(key)}</span>
+                                                <span className="text-muted truncate">{formatLabel(key, tAchievements)}</span>
                                                 <span className="font-mono text-muted/70">+0</span>
                                             </div>
                                         ))}
@@ -523,6 +527,7 @@ export const XpBreakdownModal: React.FC<{
 };
 
 export const AchievementsDashboard: React.FC<{ sessionInfo?: any }> = ({ sessionInfo = null }) => {
+    const { tAchievements } = useAchievementsI18n();
     const [data, setData] = useState<any>(null);
     const [board, setBoard] = useState<any[]>([]);
     const [boardPage, setBoardPage] = useState(0);
@@ -1275,6 +1280,7 @@ export const AchievementsHomeWidget: React.FC<{
     summary: any;
     onOpen?: () => void;
 }> = ({ summary, onOpen }) => {
+    const { tAchievements } = useAchievementsI18n();
     if (!summary) return null;
     const lp = summary.levelProgress || {};
     const recent = (summary.recentEarned || summary.earned?.slice?.(0, 6) || []) as any[];

--- a/client/achievements/BadgeDetailDrawer.tsx
+++ b/client/achievements/BadgeDetailDrawer.tsx
@@ -3,7 +3,7 @@ import { Pin, PinOff, X, Lock, Calendar, Trophy, Flag } from 'lucide-react';
 import { apiFetch } from '../shared/api';
 import { logoUrl, portalUrl, resolvePortalAssetUrl } from '../shared/basePath';
 import { ModalPortal } from '../shared/ModalPortal';
-import { tAchievements } from './i18n';
+import { tAchievements, useAchievementsI18n } from './i18n';
 
 const rarityClass = (rarity: string) => {
     // Border + text only — never set translucent bg on the panel itself.
@@ -56,6 +56,7 @@ export const BadgeDetailDrawer: React.FC<Props> = ({
     onTogglePin,
     pinBusy,
 }) => {
+    const { tAchievements } = useAchievementsI18n();
     const [detail, setDetail] = useState<any>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);

--- a/client/achievements/LeaderboardDossierModal.tsx
+++ b/client/achievements/LeaderboardDossierModal.tsx
@@ -6,7 +6,7 @@ import {
 import { apiFetch } from '../shared/api';
 import { logoUrl, portalUrl, resolvePortalAssetUrl } from '../shared/basePath';
 import { ModalPortal } from '../shared/ModalPortal';
-import { tAchievements } from './i18n';
+import { tAchievements, useAchievementsI18n } from './i18n';
 
 const PANEL_FALLBACK = '#12141a';
 const PANEL_BG = 'rgb(var(--color-card))';
@@ -33,8 +33,8 @@ const resolveAvatar = (thumb: string | null | undefined, size = 160) => {
     return portalUrl(`/api/plex/image?path=${encodeURIComponent(thumb)}&width=${size}&height=${size}`);
 };
 
-const formatXpLabel = (key: string) => {
-    const mapped = tAchievements(`xp.source.${key}`);
+const formatXpLabel = (key: string, translate = tAchievements) => {
+    const mapped = translate(`xp.source.${key}`);
     return mapped.startsWith('xp.source.') ? key : mapped;
 };
 
@@ -47,6 +47,7 @@ type Props = {
 };
 
 export const LeaderboardDossierModal: React.FC<Props> = ({ query, onClose, onOpenBadge }) => {
+    const { tAchievements } = useAchievementsI18n();
     const [data, setData] = useState<any>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -358,7 +359,7 @@ export const LeaderboardDossierModal: React.FC<Props> = ({ query, onClose, onOpe
                                                         {tAchievements('dossier.signature')}
                                                     </p>
                                                     <p className="text-sm font-bold text-text mt-1">
-                                                        {formatXpLabel(String(data.signature.label || data.signature.key))}
+                                                        {formatXpLabel(String(data.signature.label || data.signature.key), tAchievements)}
                                                     </p>
                                                     <p className="text-xs font-mono text-plex mt-0.5">
                                                         {Number(data.signature.value || 0).toLocaleString()}

--- a/client/achievements/UnlockCelebration.tsx
+++ b/client/achievements/UnlockCelebration.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Sparkles, X } from 'lucide-react';
 import { ModalPortal } from '../shared/ModalPortal';
-import { tAchievements } from './i18n';
+import { tAchievements, useAchievementsI18n } from './i18n';
 
 type Props = {
     badges: Array<{ id?: string; name?: string; icon?: string }>;
@@ -12,6 +12,7 @@ const CONFETTI_COLORS = ['#e5a00d', '#38bdf8', '#a78bfa', '#34d399', '#f472b6', 
 
 /** Full-screen unlock moment with lightweight CSS confetti. Respect mute at call site. */
 export const UnlockCelebration: React.FC<Props> = ({ badges, onClose }) => {
+    const { tAchievements } = useAchievementsI18n();
     const [visible, setVisible] = useState(true);
     const pieces = useMemo(
         () => Array.from({ length: 36 }, (_, i) => ({

--- a/client/achievements/i18n.ts
+++ b/client/achievements/i18n.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+import { useDiscoverI18n } from '../discovery/i18n';
 import { readDiscoverUiLocale, type DiscoverLocale } from '../discovery/i18n/types';
 
 const catalogs: Record<DiscoverLocale, Record<string, string>> = {
@@ -509,4 +511,13 @@ export const tAchievements = (
         }
     }
     return text;
+};
+
+export const useAchievementsI18n = () => {
+    const { locale } = useDiscoverI18n();
+    const tAchievementsForLocale = useCallback((
+        key: string,
+        vars?: Record<string, string | number>,
+    ) => tAchievements(key, vars, locale), [locale]);
+    return { locale, tAchievements: tAchievementsForLocale };
 };

--- a/client/shared/ShareAchievements.tsx
+++ b/client/shared/ShareAchievements.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useRef, useState } from 'react';
 import { X, Copy, Download, Share2 } from 'lucide-react';
 import html2canvas from 'html2canvas';
 import { getPublicOrigin } from './basePath';
-import { tAchievements } from '../achievements/i18n';
+import { tAchievements, useAchievementsI18n } from '../achievements/i18n';
 
 const EXPORT_WIDTH_PX = 1080;
 
@@ -17,21 +17,21 @@ const waitForExportImages = (root: HTMLElement) => Promise.all(
     }),
 );
 
-export const buildAchievementsShareText = (me: any, serverName: string, rank?: number | null) => {
+export const buildAchievementsShareText = (me: any, serverName: string, rank?: number | null, translate = tAchievements) => {
     const recent = Array.isArray(me?.recentEarned) ? me.recentEarned.slice(0, 5) : [];
     const origin = typeof window !== 'undefined' ? window.location.origin : getPublicOrigin();
     const lines = [
-        `🏆 ${tAchievements('share.textTitle', { serverName })}`,
+        `🏆 ${translate('share.textTitle', { serverName })}`,
         me?.username ? `👤 ${me.username}` : '',
         '',
-        `⭐ ${tAchievements('share.textLevelXp', { level: me?.level || 1, xp: (Number(me?.xp) || 0).toLocaleString() })}`,
-        rank ? `🏅 ${tAchievements('share.textRank', { rank })}` : '',
-        `🎖️ ${tAchievements('dossier.badgeCount', { earned: me?.earnedCount || 0, total: me?.totalBadges || 0 })}`,
+        `⭐ ${translate('share.textLevelXp', { level: me?.level || 1, xp: (Number(me?.xp) || 0).toLocaleString() })}`,
+        rank ? `🏅 ${translate('share.textRank', { rank })}` : '',
+        `🎖️ ${translate('dossier.badgeCount', { earned: me?.earnedCount || 0, total: me?.totalBadges || 0 })}`,
         recent.length
-            ? `✨ ${tAchievements('share.textRecent', { names: recent.map((b: any) => b?.name).filter(Boolean).join(', ') })}`
+            ? `✨ ${translate('share.textRecent', { names: recent.map((b: any) => b?.name).filter(Boolean).join(', ') })}`
             : '',
         '',
-        tAchievements('share.textSharedFrom', { origin }),
+        translate('share.textSharedFrom', { origin }),
     ].filter(Boolean);
     return lines.join('\n');
 };
@@ -51,6 +51,7 @@ export const ShareAchievementsModal: React.FC<Props> = ({
     onClose,
     onToast,
 }) => {
+    const { tAchievements } = useAchievementsI18n();
     const exportRef = useRef<HTMLDivElement>(null);
     const [busy, setBusy] = useState<'copy' | 'download' | 'share' | null>(null);
     const lp = me?.levelProgress || {};
@@ -88,7 +89,7 @@ export const ShareAchievementsModal: React.FC<Props> = ({
     const handleCopyText = async () => {
         setBusy('copy');
         try {
-            await navigator.clipboard.writeText(buildAchievementsShareText(me, serverName, rank));
+            await navigator.clipboard.writeText(buildAchievementsShareText(me, serverName, rank, tAchievements));
             onToast?.(tAchievements('share.copied'), 'success');
         } catch {
             onToast?.(tAchievements('share.copyFailed'), 'error');
@@ -121,7 +122,7 @@ export const ShareAchievementsModal: React.FC<Props> = ({
 
     const handleShare = async () => {
         setBusy('share');
-        const text = buildAchievementsShareText(me, serverName, rank);
+        const text = buildAchievementsShareText(me, serverName, rank, tAchievements);
         try {
             if (!navigator.share) {
                 await navigator.clipboard.writeText(text);


### PR DESCRIPTION
Fixes #117

Achievements and Analytics were reading the updated locale through tAchievements(), but their rendered React components were not subscribed to the Discover locale state.

This adds a small feature-local useAchievementsI18n() hook that:

subscribes to useDiscoverI18n()
passes the current React locale to tAchievements()
preserves the existing Achievements translation catalog and fallback behavior

Updated the rendered Achievements-related components to use the reactive translator.

No translation strings or existing English wording were changed.

Verification
npm.cmd run build:js ✅
git diff --check ✅
Achievements / Analytics update immediately after changing language
Existing Home locale behavior remains unchanged
Achievements feature-local i18n catalog remains intact
No unrelated files changed

Existing unrelated build warnings remain in client/poster-sets/usePosterSetsDashboard.ts for duplicate watchesCategoryFilter keys.