### PR TITLE
feat(i18n): add per-user language preference and browser locale detection

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -599,7 +599,10 @@ export const MainApp: React.FC = () => {
     };
 
     return (
-        <DiscoverI18nProvider>
+        <DiscoverI18nProvider
+            accountId={sessionInfo?.account?.id}
+            accountLocale={sessionInfo?.account?.uiLocale}
+        >
         {/* Viewport-locked shell on all breakpoints so mobile touch-scroll uses one root
             (#main-scroll-container). Nested overflow-x clip otherwise creates competing
             scrollports and breaks scrolling after opening a nav module (issue #92).

--- a/client/discovery/i18n/index.tsx
+++ b/client/discovery/i18n/index.tsx
@@ -1,12 +1,15 @@
-import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { apiFetch } from '../../shared/api';
 import { en } from './en';
 import { fr } from './fr';
 import { de } from './de';
 import { es } from './es';
 import {
-    DISCOVER_UI_LOCALE_KEY,
+    detectDiscoverBrowserLocale,
+    isDiscoverLocale,
     normalizeDiscoverLocale,
-    readDiscoverUiLocale,
+    readStoredDiscoverUiLocale,
+    setDiscoverUiLocale,
     type DiscoverLocale,
     type DiscoverTranslate,
     type DiscoverTranslateVars,
@@ -159,20 +162,47 @@ type DiscoverI18nContextValue = {
 
 const DiscoverI18nContext = createContext<DiscoverI18nContextValue | null>(null);
 
-export const DiscoverI18nProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export const DiscoverI18nProvider: React.FC<{
+    children: React.ReactNode;
+    accountLocale?: unknown;
+    accountId?: unknown;
+}> = ({ children, accountLocale, accountId }) => {
+    const accountKey = String(accountId || '');
+    const previousAccountKey = useRef(accountKey);
+    const explicitLocale = useRef<DiscoverLocale | null>(null);
     const [locale, setLocaleState] = useState<DiscoverLocale>(() => (
-        typeof window !== 'undefined' ? readDiscoverUiLocale() : 'en'
+        isDiscoverLocale(accountLocale)
+            ? accountLocale
+            : (readStoredDiscoverUiLocale() || detectDiscoverBrowserLocale())
     ));
 
     const setLocale = useCallback((next: DiscoverLocale) => {
         const normalized = normalizeDiscoverLocale(next);
+        explicitLocale.current = normalized;
         setLocaleState(normalized);
-        try {
-            localStorage.setItem(DISCOVER_UI_LOCALE_KEY, normalized);
-        } catch {
-            /* ignore */
-        }
+        setDiscoverUiLocale(normalized);
+        void apiFetch('/api/users/preferences', {
+            method: 'POST',
+            body: JSON.stringify({ uiLocale: normalized }),
+        }).catch(() => {
+            // Local state remains authoritative when account persistence is unavailable.
+        });
     }, []);
+
+    React.useEffect(() => {
+        if (previousAccountKey.current !== accountKey) {
+            previousAccountKey.current = accountKey;
+            explicitLocale.current = null;
+        }
+        if (!isDiscoverLocale(accountLocale)) return;
+        if (explicitLocale.current) return;
+        setLocaleState(accountLocale);
+        setDiscoverUiLocale(accountLocale);
+    }, [accountId, accountKey, accountLocale]);
+
+    React.useEffect(() => {
+        setDiscoverUiLocale(locale);
+    }, [locale]);
 
     const t = useMemo(() => createDiscoverTranslate(locale), [locale]);
 

--- a/client/discovery/i18n/types.ts
+++ b/client/discovery/i18n/types.ts
@@ -12,12 +12,24 @@ export const DISCOVER_UI_LOCALE_KEY = 'discoverUiLocale';
 /** Sent on discovery proxy/search calls so the server can localize TMDB metadata. */
 export const DISCOVER_LOCALE_HEADER = 'X-Portal-Discover-Locale';
 
+let activeDiscoverUiLocale: DiscoverLocale | null = null;
+
 export const isDiscoverLocale = (value: unknown): value is DiscoverLocale => (
     DISCOVER_LOCALES.some((locale) => locale.code === value)
 );
 
+/** Match an exact or regional browser locale to one of the supported catalogs. */
+export const matchDiscoverLocale = (value: unknown): DiscoverLocale | null => {
+    const raw = String(value || '').trim().toLowerCase().replace(/_/g, '-');
+    if (!raw) return null;
+    const exact = DISCOVER_LOCALES.find((locale) => locale.code === raw);
+    if (exact) return exact.code;
+    const base = raw.split('-')[0];
+    return DISCOVER_LOCALES.find((locale) => locale.code === base)?.code || null;
+};
+
 export const normalizeDiscoverLocale = (value: unknown): DiscoverLocale => (
-    isDiscoverLocale(value) ? value : 'en'
+    matchDiscoverLocale(value) || 'en'
 );
 
 /** TMDB / Seerr metadata language codes for our supported UI locales. */
@@ -27,11 +39,39 @@ export const discoverLocaleToTmdbLanguage = (locale: unknown): DiscoverLocale =>
 
 export const readDiscoverUiLocale = (): DiscoverLocale => {
     try {
+        if (activeDiscoverUiLocale) return activeDiscoverUiLocale;
         if (typeof localStorage === 'undefined') return 'en';
         return normalizeDiscoverLocale(localStorage.getItem(DISCOVER_UI_LOCALE_KEY));
     } catch {
         return 'en';
     }
+};
+
+export const setDiscoverUiLocale = (locale: DiscoverLocale): void => {
+    activeDiscoverUiLocale = locale;
+    try {
+        localStorage.setItem(DISCOVER_UI_LOCALE_KEY, locale);
+    } catch {
+        /* ignore */
+    }
+};
+
+export const readStoredDiscoverUiLocale = (): DiscoverLocale | null => {
+    try {
+        if (typeof localStorage === 'undefined') return null;
+        return matchDiscoverLocale(localStorage.getItem(DISCOVER_UI_LOCALE_KEY));
+    } catch {
+        return null;
+    }
+};
+
+export const detectDiscoverBrowserLocale = (): DiscoverLocale => {
+    if (typeof navigator === 'undefined') return 'en';
+    const candidates = [
+        ...(Array.isArray(navigator.languages) ? navigator.languages : []),
+        navigator.language,
+    ];
+    return candidates.map(matchDiscoverLocale).find((locale): locale is DiscoverLocale => !!locale) || 'en';
 };
 
 export type DiscoverTranslateVars = Record<string, string | number>;

--- a/client/preferences/PreferencesPage.tsx
+++ b/client/preferences/PreferencesPage.tsx
@@ -6,6 +6,7 @@ import { DashboardHero, DashboardPageShell, DashboardPanel } from '../shared/das
 import { Toast, type ToastMessage } from '../shared/toast';
 import { subscribeWebPush, unsubscribeWebPush, webPushSupported } from '../shared/webPushSubscribe';
 import { useDiscoverI18n } from '../discovery/i18n';
+import { DiscoverLocaleSelect } from '../discovery/i18n/DiscoverLocaleSelect';
 
 type Props = {
     sessionInfo: any;
@@ -179,6 +180,9 @@ export const PreferencesPage: React.FC<Props> = ({ sessionInfo, refreshSession }
                 <DashboardPanel title={t('preferencesPage.unavailableTitle')} subtitle={t('preferencesPage.unavailableHint')} />
             ) : (
                 <div className="space-y-4">
+                    <DashboardPanel title={t('common.language')}>
+                        <DiscoverLocaleSelect />
+                    </DashboardPanel>
                     <DashboardPanel title={t('preferencesPage.newsletterTitle')} subtitle={t('preferencesPage.newsletterSubtitle')}>
                         <PrefToggle
                             title={t('homeDashboard.weeklyNewsletter')}

--- a/client/shared/api.ts
+++ b/client/shared/api.ts
@@ -1,8 +1,7 @@
 import { portalUrl } from './basePath';
 import {
     DISCOVER_LOCALE_HEADER,
-    DISCOVER_UI_LOCALE_KEY,
-    normalizeDiscoverLocale,
+    readDiscoverUiLocale,
 } from '../discovery/i18n/types';
 
 /** Sent on every API call so mutating routes can reject cross-site CSRF. */
@@ -17,10 +16,10 @@ const needsDiscoverMetadataLocale = (url: string) => {
 };
 
 const discoverLocaleHeaders = (url: string): HeadersInit => {
-    if (typeof localStorage === 'undefined' || !needsDiscoverMetadataLocale(url)) return {};
+    if (!needsDiscoverMetadataLocale(url)) return {};
     try {
         return {
-            [DISCOVER_LOCALE_HEADER]: normalizeDiscoverLocale(localStorage.getItem(DISCOVER_UI_LOCALE_KEY)),
+            [DISCOVER_LOCALE_HEADER]: readDiscoverUiLocale(),
         };
     } catch {
         return {};

--- a/index.js
+++ b/index.js
@@ -3779,6 +3779,7 @@ app.post('/api/users/preferences', requireAuth, requireMember, async (req, res) 
             notifyNewEpisodeWebPush,
             notifyWebPush,
             showDiscoverNowPlaying,
+            uiLocale,
         } = req.body || {};
         const users = await loadFile(USERS_PATH, []);
         const localUser = findLocalUserForSession(users, req.user);
@@ -3794,6 +3795,13 @@ app.post('/api/users/preferences', requireAuth, requireMember, async (req, res) 
             if (oldPref !== !!optOutNewsletter) {
                 await appendAuditLog(optOutNewsletter ? 'newsletter_opt_out' : 'newsletter_opt_in', req.user, req.user);
             }
+        }
+        if (uiLocale !== undefined) {
+            const normalizedLocale = String(uiLocale || '').trim().toLowerCase();
+            if (!['en', 'fr', 'de', 'es'].includes(normalizedLocale)) {
+                return res.status(400).json({ error: 'Unsupported locale' });
+            }
+            users[userIndex].uiLocale = normalizedLocale;
         }
         const boolPrefs = {
             notifyRequestAvailableEmail,


### PR DESCRIPTION
Implements #126.

What this adds
Per-user uiLocale persistence through the existing /api/users/preferences endpoint
Automatic browser locale detection using navigator.languages / navigator.language
Regional locale matching such as fr-FR → fr
Existing discoverUiLocale localStorage support preserved for backward compatibility
Account-level locale takes precedence when available
Existing DiscoverI18nProvider remains the single reactive locale state
Language selector added to the user Preferences page
Discover metadata requests now use the active resolved locale
Locale priority
Saved account locale
Existing localStorage locale
Browser locale
English fallback

Current supported locales remain:

English
French
German
Spanish
Admin fallback

For server-owner admin accounts without a corresponding local users.json entry, language switching still works through the existing reactive provider and localStorage fallback.

No separate admin locale store or user-model refactor was introduced.

Validation
npm test: 58 passed, 0 failed
npm run build:js: passed
git diff --check: passed
No translation catalog changes required
No unrelated source changes

The existing unrelated Poster Sets duplicate-key build warnings remain unchanged.

Closes #126