### PR TITLE
fix(i18n): centralize language selection in preferences

### DIFF
--- a/client/screens.tsx
+++ b/client/screens.tsx
@@ -35,7 +35,6 @@ import { AuthPageBackground, themeClasses, SlideshowBackground } from './shared/
 import { activityStreamColumnCount, activityStreamGridClass, upgraderPosterGridClass, upgraderPosterGridStyle, type UpgraderGridSize } from './shared/portalLayout';
 import { DiscoverGridSizeSelect } from './discovery/DiscoverGridSizeSelect';
 import { useDiscoverGridSize } from './discovery/useDiscoverGridSize';
-import { DiscoverLocaleSelect } from './discovery/i18n/DiscoverLocaleSelect';
 import { useDiscoverI18n } from './discovery/i18n';
 import { DiscoverNowPlayingStrip } from './discovery/DiscoverNowPlayingStrip';
 import { useNowPlaying } from './shared/useNowPlaying';
@@ -11654,7 +11653,6 @@ export const Navigation: React.FC<NavigationProps> = ({ currentRoute, onNavigate
                         className="overflow-visible"
                         buttonClassName="relative w-8 h-8 flex items-center justify-center rounded-md border border-border text-muted hover:border-plex/50 hover:text-text transition-all overflow-visible"
                     />
-                    <DiscoverLocaleSelect showLabel={false} className="w-[6.75rem]" />
                     <div className="relative" ref={mobileThemeRef}>
                         <button
                             onClick={() => setMobileThemeOpen(v => !v)}
@@ -11778,7 +11776,6 @@ export const Navigation: React.FC<NavigationProps> = ({ currentRoute, onNavigate
                                 {appVersion}
                             </div>
                         )}
-                        <DiscoverLocaleSelect variant="text" />
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Follow-up to #127.

This removes the duplicate portal language selectors from the navigation and keeps language selection centralized in the new Preferences page.

### Changes

* Removed the mobile navigation language selector
* Removed the desktop/sidebar language selector
* Removed the now-unused `DiscoverLocaleSelect` import from `client/screens.tsx`

The per-user language persistence, browser locale detection, localStorage fallback, reactive i18n provider, and Preferences language selector remain unchanged.

### Validation

* `npm test`: 58 passed, 0 failed
* `npm run build:js`: passed
* `git diff --check`: passed

Only `client/screens.tsx` is changed.

Existing unrelated Poster Sets duplicate-key build warnings remain unchanged.
