### PR TITLE
fix(ui): simplify iOS PWA bottom nav docking

### DIFF
--- a/client/screens.tsx
+++ b/client/screens.tsx
@@ -12096,9 +12096,7 @@ export const Navigation: React.FC<NavigationProps> = ({ currentRoute, onNavigate
                         <div
                             ref={firefoxNavBarRef}
                             className={`md:hidden fixed inset-x-0 bottom-0 w-full max-w-full nav-shell border-t z-[310] overflow-visible ${bottomSafeClass}`}
-                            style={iosMobileNav
-                                ? { top: 'auto', bottom: 'calc(100svh - 100lvh)' }
-                                : { bottom: 0 }}
+                            style={{ bottom: 0 }}
                         >
                             {navInner}
                             <div

--- a/client/shared/useFirefoxMobileNavShell.ts
+++ b/client/shared/useFirefoxMobileNavShell.ts
@@ -37,29 +37,13 @@ export const isStandaloneDisplayMode = () => {
 };
 
 /**
- * Firefox Android + iOS Safari/PWA leave `position:fixed; bottom:0` stranded
- * when the dynamic toolbar collapses (or the layout viewport is shorter than
- * the screen). Pin the bar so its bottom edge matches the visible viewport,
- * and extend to the layout bottom when chrome is gone so no black gap remains.
+ * Firefox Android needs explicit visual-viewport docking when its dynamic
+ * toolbar changes. iOS uses the same body portal, but keeps the native
+ * `bottom: 0` anchor so layout, visual, and screen coordinates are not mixed.
  *
  * Chrome / Chromium Android PWA must not use this path — plain CSS `bottom:0`
  * is correct there.
  */
-const readLargeViewportHeight = () => {
-    if (typeof document === 'undefined') return 0;
-    try {
-        const probe = document.createElement('div');
-        probe.setAttribute('aria-hidden', 'true');
-        probe.style.cssText = 'position:fixed;top:0;left:0;width:0;height:100lvh;pointer-events:none;visibility:hidden';
-        document.body.appendChild(probe);
-        const height = probe.offsetHeight || 0;
-        probe.remove();
-        return height;
-    } catch {
-        return 0;
-    }
-};
-
 export function useFirefoxMobileNavShell({ barRef, enabled }: Options) {
     useEffect(() => {
         if (!enabled || typeof window === 'undefined') return;
@@ -67,7 +51,6 @@ export function useFirefoxMobileNavShell({ barRef, enabled }: Options) {
         let raf = 0;
         let lastTop: number | string = Number.NaN;
         const ios = isIosMobileClient();
-        const largeViewportHeight = ios ? readLargeViewportHeight() : 0;
 
         const clearInline = (bar: HTMLElement) => {
             bar.style.position = '';
@@ -87,18 +70,10 @@ export function useFirefoxMobileNavShell({ barRef, enabled }: Options) {
 
             const vv = window.visualViewport;
             const barH = Math.max(bar.offsetHeight || 0, 56);
-            const landscape = window.innerWidth > window.innerHeight;
-            const screenFloor = ios
-                ? (landscape
-                    ? Math.min(window.screen?.width || 0, window.screen?.height || 0)
-                    : Math.max(window.screen?.width || 0, window.screen?.height || 0))
-                : 0;
             const layoutBottom = Math.max(
                 window.innerHeight || 0,
                 document.documentElement?.clientHeight || 0,
                 vv ? Math.ceil(vv.height + vv.offsetTop) : 0,
-                largeViewportHeight,
-                screenFloor,
             );
             const visualBottom = vv ? (vv.offsetTop + vv.height) : layoutBottom;
             const isZoomed = vv ? Math.abs(vv.scale - 1) > 0.01 : false;
@@ -122,16 +97,14 @@ export function useFirefoxMobileNavShell({ barRef, enabled }: Options) {
             bar.style.margin = '0';
             bar.style.transform = 'translateZ(0)';
 
-            if (ios && !isZoomed) {
-                // iOS `position:fixed` is visual-viewport-relative. `bottom:0` therefore
-                // sits above Safari's chrome on first load. Shift down by the gap to
-                // the large/screen viewport so the bar starts on the device bottom.
-                const gap = Math.round(visualBottom - dockBottom);
-                const key = `b:${gap}`;
-                if (key === lastTop) return;
-                lastTop = key;
+            if (ios) {
+                // Keep iOS on one coordinate system. The portaled fixed bar is
+                // anchored to the visual viewport; safe-area padding is handled
+                // by CSS in standalone mode.
+                if (lastTop === 'ios') return;
+                lastTop = 'ios';
                 bar.style.top = 'auto';
-                bar.style.bottom = `${gap}px`;
+                bar.style.bottom = '0px';
                 return;
             }
 

--- a/input.css
+++ b/input.css
@@ -217,9 +217,9 @@
    */
   .ios-mobile-bottom-nav {
     padding-bottom: 0;
-    /* First paint: sit on the large viewport, not above Safari's bottom chrome. */
+    /* The portaled fixed bar owns the visual viewport edge. */
     top: auto;
-    bottom: calc(100svh - 100lvh);
+    bottom: 0;
   }
 
   @media (display-mode: standalone), (display-mode: fullscreen) {


### PR DESCRIPTION
## Summary

Simplifies the iOS mobile bottom-nav positioning model to avoid mixing incompatible viewport coordinate systems.

The previous iOS implementation combined values from:

- `window.screen`
- `100lvh`
- `visualViewport`
- fixed-position coordinates
- safe-area offsets

On real iPhone hardware, the black/empty gap under the bottom navigation still remained after the existing fix and after recreating the installed home-screen app.

This change keeps the iOS path much simpler:

- keep the bottom nav portaled to `document.body`
- keep native `position: fixed; bottom: 0`
- remove `screen.height` / `100lvh` calculations from the iOS hook path
- remove the competing `calc(100svh - 100lvh)` CSS offset
- keep standalone safe-area padding for the home indicator
- preserve Firefox Android visualViewport docking
- leave Chromium Android / PWA behavior unchanged

## Scope

- `client/screens.tsx`
- `client/shared/useFirefoxMobileNavShell.ts`
- `input.css`

No navigation routes, actions, ordering, badges, i18n, or More-menu behavior were changed.

## Validation

- `npm test`: 58 passed, 0 failed
- `npm run build:js`: passed
- `git diff --check`: passed

Existing unrelated Poster Sets duplicate-key build warnings remain unchanged.

## Device validation

Real-device iPhone validation is pending deployment to Nightly.

This PR therefore does not claim that the issue is confirmed fixed on physical hardware yet.