### PR TITLE
fix(i18n): restore Overlays custom collection localization

### DIFF
--- a/client/discovery/i18n/en.ts
+++ b/client/discovery/i18n/en.ts
@@ -637,6 +637,7 @@ export const en = {
                 ruleAdded: 'Saved “{name}” — ready for Preview / Run.',
                 ruleRemoved: 'Collection overlay removed',
                 ruleRemoveFailed: 'Could not remove collection overlay',
+                uploadFailed: 'Upload failed',
                 ruleName: 'Name',
                 ruleLibrary: 'Library',
                 pickLibrary: 'Select a library…',

--- a/client/discovery/i18n/fr.ts
+++ b/client/discovery/i18n/fr.ts
@@ -628,7 +628,7 @@ export const fr: DeepPartial<EnCatalog> = {
                 },
             },
             collections: {
-                title: 'Custom Collection Overlays',
+                title: 'Overlays de collections personnalisées',
                 hint: 'Appliquez un PNG personnalisé à chaque titre d’une collection Plex (ex. Tendances).',
                 enabledOn: 'Activé · {count} règle(s)',
                 enabledOff: 'Désactivé',
@@ -639,6 +639,7 @@ export const fr: DeepPartial<EnCatalog> = {
                 ruleAdded: '« {name} » enregistré — prêt pour Aperçu / Exécuter.',
                 ruleRemoved: 'Overlay de collection supprimé',
                 ruleRemoveFailed: 'Impossible de supprimer l’overlay de collection',
+                uploadFailed: 'Échec de l’envoi',
                 ruleName: 'Nom',
                 ruleLibrary: 'Bibliothèque',
                 pickLibrary: 'Choisir une bibliothèque…',
@@ -701,7 +702,7 @@ export const fr: DeepPartial<EnCatalog> = {
             revertSectionTitle: 'Rétablir cette section ?',
             expandSection: 'Développer',
             collapseSection: 'Réduire',
-            sectionEmpty: 'Aucun titre tamponné pour cette collection. Lancez Aperçu/Exécuter sur Custom Collection Overlays.',
+            sectionEmpty: 'Aucun titre marqué pour cette collection. Lancez Aperçu/Exécuter dans Overlays de collections personnalisées.',
         },
         overview: {
             loggedOverlays: 'Séries journalisées',

--- a/client/overlays/OverlaysDashboard.tsx
+++ b/client/overlays/OverlaysDashboard.tsx
@@ -863,7 +863,7 @@ export const OverlaysDashboard: React.FC = () => {
         try {
             const up = await overlaysApi.uploadPreset('collection', newCollectionRuleFile);
             const imageId = String(up?.preset?.id || '').trim();
-            if (!imageId) throw new Error('Upload failed');
+            if (!imageId) throw new Error(t('overlays.jobs.collections.uploadFailed'));
             const sectionMeta = libraryPickerOptions.find(
                 (o) => o.value.toLowerCase() === library.toLowerCase(),
             );
@@ -897,7 +897,7 @@ export const OverlaysDashboard: React.FC = () => {
             await refresh();
             toast(t('overlays.jobs.collections.ruleAdded', { name: rule.name }));
         } catch (e: any) {
-            toast(e?.message || 'Upload failed', 'error');
+            toast(e?.message || t('overlays.jobs.collections.uploadFailed'), 'error');
         }
     }, [
         newCollectionRuleLibrary,


### PR DESCRIPTION
## Summary

Fixes a small French localization regression in Custom Collection Overlays.

- localizes the `Upload failed` fallback
- translates the Custom Collection Overlays title in French
- fixes the related French empty-state wording
- keeps backend-provided error messages unchanged

## Validation

- `npm test`: 58 passed
- `npm run build:js`: passed
- `git diff --check`: passed
- EN/FR catalog parity: 1352 / 1352