### PR TITLE
feat(i18n): localize Requests admin issues panel

### DIFF
--- a/client/discovery/i18n/en.ts
+++ b/client/discovery/i18n/en.ts
@@ -1583,6 +1583,32 @@ export const en = {
         toasts: { configureWelcome: 'Welcome! Please configure your media server settings to begin.', settingsSaved: 'Settings saved successfully!', syncedUsers: 'Synced {count} users from {mediaServerLabel}.', joinDatesUpdated: 'Updated {updated} join date(s) from watch history ({processed} checked).', noJoinDatesUpdated: 'No join dates updated — {missing} user(s) had no first-play history.', noJoinDatesNeeded: 'No join dates needed updating.', accessRevoked: 'Plex access revoked successfully.', viewingAs: 'Now viewing portal as {username}.', savedLibraryWarning: 'User saved, but Plex library access was not updated.', userUpdated: 'User updated successfully!', userRemoved: 'User removed from manager.', bulkUpdated: 'Successfully updated {count} users.', saved: 'Saved.', plexShareFailures: '{count} Plex share update(s) failed.', librariesUpdated: 'Updated libraries for {count} users.' },
         dialogs: { deleteUser: 'Are you sure you want to delete this user? This will revoke {mediaServerLabel} access first where supported.', shareAllLibraries: 'Share ALL libraries with {count} selected user(s)?', shareSelectedLibraries: 'Share {libraries} selected librar(ies) with {count} user(s)?', livePlexAccess: 'This updates their live Plex access.' },
     },
+    issuesAdmin: {
+        page: {
+            title: 'Issues',
+            openSummary: '{count} open playback issues reported by users',
+            connectHint: 'Connect Seerr in Settings → Integrations to manage issues here.',
+        },
+        filters: { open: 'Open', resolved: 'Resolved' },
+        actions: {
+            openSeerr: 'Open Seerr', refresh: 'Refresh', sendReply: 'Send Reply', deleting: 'Deleting…', deleteIssue: 'Delete Issue',
+        },
+        labels: { updated: 'Updated', reportedBy: 'Reported by' },
+        empty: {
+            noIssues: 'No {filter} issues',
+            reportHint: 'Users can report playback problems from available titles in Discover.',
+        },
+        errors: {
+            cannotConnect: 'Cannot connect to your request app', loadIssues: 'Failed to load issues', update: 'Failed to update issue',
+            addComment: 'Failed to add comment', delete: 'Failed to delete issue',
+        },
+        toasts: {
+            resolvedTitle: 'Resolved "{title}"', reopenedTitle: 'Reopened "{title}"', commentAddedTitle: 'Comment added to "{title}"', deletedTitle: 'Deleted issue for "{title}"',
+        },
+        dialogs: {
+            replyTitle: 'Reply to issue', replyPlaceholder: 'Reply to the user…', deleteBody: 'Permanently delete the issue for {title}?',
+        },
+    },
     person: {
         back: 'Back to Discovery',
         biography: 'Biography',

--- a/client/discovery/i18n/fr.ts
+++ b/client/discovery/i18n/fr.ts
@@ -1585,6 +1585,32 @@ export const fr: DeepPartial<EnCatalog> = {
         toasts: { configureWelcome: 'Bienvenue ! Configurez les réglages de votre serveur multimédia pour commencer.', settingsSaved: 'Réglages enregistrés !', syncedUsers: '{count} utilisateur(s) synchronisé(s) depuis {mediaServerLabel}.', joinDatesUpdated: '{updated} date(s) d’inscription mise(s) à jour depuis l’historique de lecture ({processed} vérifié(s)).', noJoinDatesUpdated: 'Aucune date mise à jour — {missing} utilisateur(s) sans historique de première lecture.', noJoinDatesNeeded: 'Aucune date d’inscription ne nécessite de mise à jour.', accessRevoked: 'Accès Plex révoqué avec succès.', viewingAs: 'Affichage du portail en tant que {username}.', savedLibraryWarning: 'Utilisateur enregistré, mais l’accès aux bibliothèques Plex n’a pas été mis à jour.', userUpdated: 'Utilisateur mis à jour !', userRemoved: 'Utilisateur retiré du gestionnaire.', bulkUpdated: '{count} utilisateur(s) mis à jour avec succès.', saved: 'Enregistré.', plexShareFailures: '{count} mise(s) à jour du partage Plex ont échoué.', librariesUpdated: 'Bibliothèques mises à jour pour {count} utilisateur(s).' },
         dialogs: { deleteUser: 'Voulez-vous vraiment supprimer cet utilisateur ? L’accès {mediaServerLabel} sera d’abord révoqué si possible.', shareAllLibraries: 'Partager TOUTES les bibliothèques avec {count} utilisateur(s) sélectionné(s) ?', shareSelectedLibraries: 'Partager {libraries} bibliothèque(s) sélectionnée(s) avec {count} utilisateur(s) ?', livePlexAccess: 'Cela met à jour leur accès Plex actuel.' },
     },
+    issuesAdmin: {
+        page: {
+            title: 'Signalements',
+            openSummary: '{count} signalement(s) de lecture ouvert(s) signalé(s) par les utilisateurs',
+            connectHint: 'Connectez Seerr dans Réglages → Intégrations pour gérer les signalements ici.',
+        },
+        filters: { open: 'Ouverts', resolved: 'Résolus' },
+        actions: {
+            openSeerr: 'Ouvrir Seerr', refresh: 'Actualiser', sendReply: 'Envoyer la réponse', deleting: 'Suppression…', deleteIssue: 'Supprimer le signalement',
+        },
+        labels: { updated: 'Mis à jour', reportedBy: 'Signalé par' },
+        empty: {
+            noIssues: 'Aucun signalement {filter}',
+            reportHint: 'Les utilisateurs peuvent signaler un problème de lecture depuis les titres disponibles dans Discover.',
+        },
+        errors: {
+            cannotConnect: 'Impossible de se connecter à votre application de demandes', loadIssues: 'Échec du chargement des signalements', update: 'Échec de la mise à jour du signalement',
+            addComment: 'Échec de l’ajout du commentaire', delete: 'Échec de la suppression du signalement',
+        },
+        toasts: {
+            resolvedTitle: '« {title} » résolu', reopenedTitle: '« {title} » rouvert', commentAddedTitle: 'Commentaire ajouté à « {title} »', deletedTitle: 'Signalement supprimé pour « {title} »',
+        },
+        dialogs: {
+            replyTitle: 'Répondre au signalement', replyPlaceholder: 'Répondre à l’utilisateur…', deleteBody: 'Supprimer définitivement le signalement pour {title} ?',
+        },
+    },
     person: {
         back: 'Retour à Discover',
         biography: 'Biographie',

--- a/client/requests/IssuesAdminPanel.tsx
+++ b/client/requests/IssuesAdminPanel.tsx
@@ -22,16 +22,18 @@ import {
     formatIssueRelativeTime,
     issueStatusBadgeClass,
 } from '../discovery/issueUtils';
+import { useDiscoverI18n } from '../discovery/i18n';
 
 type IssueFilter = 'open' | 'resolved';
 
-const IssueTypeBadge: React.FC<{ type: string }> = ({ type }) => (
+const IssueTypeBadge: React.FC<{ type: string; t: ReturnType<typeof useDiscoverI18n>['t'] }> = ({ type, t }) => (
     <span className="text-[10px] uppercase tracking-wider font-bold px-2 py-0.5 rounded-full bg-white/5 border border-border text-muted">
-        {type === 'tv' ? 'TV' : 'Movie'}
+        {type === 'tv' ? t('mediaType.tv') : t('mediaType.movie')}
     </span>
 );
 
 export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ onCountsChange }) => {
+    const { t } = useDiscoverI18n();
     const [toasts, setToasts] = useState<ToastMessage[]>([]);
     const [filter, setFilter] = useState<IssueFilter>('open');
     const [issues, setIssues] = useState<PortalIssueItem[]>([]);
@@ -77,34 +79,34 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
             }
             if (!nextCounts.supported || !nextCounts.connected) {
                 setIssues([]);
-                setError(countData?.error || 'Cannot connect to your request app');
+                setError(countData?.error || t('issuesAdmin.errors.cannotConnect'));
                 return;
             }
 
             const listData = await apiFetch(`/api/issues?filter=${encodeURIComponent(filter)}&take=30`);
             if (listData?.connected === false) {
                 setIssues([]);
-                setError(listData?.error || 'Cannot connect to your request app');
+                setError(listData?.error || t('issuesAdmin.errors.cannotConnect'));
                 return;
             }
             setIssues(Array.isArray(listData?.results) ? listData.results : []);
         } catch (e: any) {
-            setError(e?.message || 'Failed to load issues');
+            setError(e?.message || t('issuesAdmin.errors.loadIssues'));
             setIssues([]);
         } finally {
             setLoading(false);
             setRefreshing(false);
         }
-    }, [filter]);
+    }, [filter, t]);
 
     useEffect(() => {
         loadData();
     }, [loadData]);
 
     const filterTabs = useMemo(() => ([
-        { id: 'open' as const, label: 'Open', count: counts.open },
-        { id: 'resolved' as const, label: 'Resolved', count: counts.closed },
-    ]), [counts]);
+        { id: 'open' as const, label: t('issuesAdmin.filters.open'), count: counts.open },
+        { id: 'resolved' as const, label: t('issuesAdmin.filters.resolved'), count: counts.closed },
+    ]), [counts, t]);
 
     const handleStatus = async (item: PortalIssueItem, status: 'open' | 'resolved') => {
         setActionId(item.id);
@@ -113,11 +115,13 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                 method: 'POST',
                 body: JSON.stringify({ title: item.title }),
             });
-            addToast(status === 'resolved' ? `Resolved "${item.title}"` : `Reopened "${item.title}"`);
+            addToast(status === 'resolved'
+                ? t('issuesAdmin.toasts.resolvedTitle', { title: item.title })
+                : t('issuesAdmin.toasts.reopenedTitle', { title: item.title }));
             await loadData({ silent: true });
             onCountsChange?.();
         } catch (e: any) {
-            addToast(e?.message || 'Failed to update issue', 'error');
+            addToast(e?.message || t('issuesAdmin.errors.update'), 'error');
         } finally {
             setActionId(null);
         }
@@ -131,12 +135,12 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                 method: 'POST',
                 body: JSON.stringify({ message: commentText.trim() }),
             });
-            addToast(`Comment added to "${commentTarget.title}"`);
+            addToast(t('issuesAdmin.toasts.commentAddedTitle', { title: commentTarget.title }));
             setCommentTarget(null);
             setCommentText('');
             await loadData({ silent: true });
         } catch (e: any) {
-            addToast(e?.message || 'Failed to add comment', 'error');
+            addToast(e?.message || t('issuesAdmin.errors.addComment'), 'error');
         } finally {
             setActionId(null);
         }
@@ -147,12 +151,12 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
         setActionId(deleteTarget.id);
         try {
             await apiFetch(`/api/issues/${deleteTarget.id}`, { method: 'DELETE' });
-            addToast(`Deleted issue for "${deleteTarget.title}"`);
+            addToast(t('issuesAdmin.toasts.deletedTitle', { title: deleteTarget.title }));
             setDeleteTarget(null);
             await loadData({ silent: true });
             onCountsChange?.();
         } catch (e: any) {
-            addToast(e?.message || 'Failed to delete issue', 'error');
+            addToast(e?.message || t('issuesAdmin.errors.delete'), 'error');
         } finally {
             setActionId(null);
         }
@@ -167,13 +171,13 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
 
             <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
                 <div>
-                    <h2 className="text-2xl md:text-3xl font-bold text-plex">Issues</h2>
+                    <h2 className="text-2xl md:text-3xl font-bold text-plex">{t('issuesAdmin.page.title')}</h2>
                     <p className="text-sm text-muted mt-1">
                         {counts.configured && counts.connected
-                            ? `${counts.open} open playback issues reported by users`
+                            ? t('issuesAdmin.page.openSummary', { count: counts.open })
                             : counts.configured
                                 ? 'Request app is configured — connection failed (see below)'
-                                : 'Connect Seerr in Settings → Integrations to manage issues here.'}
+                                : t('issuesAdmin.page.connectHint')}
                     </p>
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
@@ -184,7 +188,7 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                             rel="noreferrer"
                             className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-border text-sm font-medium text-muted hover:text-text hover:bg-white/5 transition-colors"
                         >
-                            Open Seerr <ExternalLink className="w-4 h-4" />
+                            {t('issuesAdmin.actions.openSeerr')} <ExternalLink className="w-4 h-4" />
                         </a>
                     )}
                     <button
@@ -194,7 +198,7 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                         className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-border text-text text-sm font-semibold hover:bg-opacity-80 transition-colors disabled:opacity-50"
                     >
                         <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
-                        Refresh
+                        {t('issuesAdmin.actions.refresh')}
                     </button>
                 </div>
             </div>
@@ -226,15 +230,15 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
 
                 {!error && issues.length === 0 && !loading && (
                     <div className="py-12 text-center text-muted">
-                        <p className="font-semibold text-text">No {filter} issues</p>
-                        <p className="text-sm mt-2">Users can report playback problems from available titles in Discover.</p>
+                        <p className="font-semibold text-text">{t('issuesAdmin.empty.noIssues', { filter: t(`issuesAdmin.filters.${filter}` as any) })}</p>
+                        <p className="text-sm mt-2">{t('issuesAdmin.empty.reportHint')}</p>
                     </div>
                 )}
 
                 <div className="flex flex-col gap-3">
                     {issues.map((item) => {
                         const busy = actionId === item.id;
-                        const location = formatIssueLocation(item);
+                        const location = formatIssueLocation(item, t);
                         const firstComment = item.comments?.[0]?.message;
                         const isOpen = item.statusLabel === 'open';
 
@@ -255,7 +259,7 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                                         </div>
                                         <div className="min-w-0 flex-1">
                                             <div className="flex flex-wrap items-center gap-2 mb-1.5">
-                                                <IssueTypeBadge type={item.type} />
+                                                <IssueTypeBadge type={item.type} t={t} />
                                                 <span className="text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full border bg-white/5 border-border text-muted">
                                                     {item.issueTypeLabel}
                                                 </span>
@@ -268,9 +272,9 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                                                 {item.year ? <span className="text-muted font-semibold ml-2">{item.year}</span> : null}
                                             </h3>
                                             <p className="text-xs text-muted mt-1">
-                                                Reported by {item.createdBy.displayName}
+                                                {t('issuesAdmin.labels.reportedBy')} {item.createdBy.displayName}
                                                 {' · '}
-                                                {formatIssueRelativeTime(item.createdAt || item.updatedAt)}
+                                                {formatIssueRelativeTime(item.createdAt || item.updatedAt, t)}
                                                 {location ? ` · ${location}` : ''}
                                             </p>
                                             {firstComment && (
@@ -278,7 +282,7 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                                             )}
                                             {item.updatedAt && item.updatedAt !== item.createdAt && (
                                                 <p className="text-[11px] text-muted/70 mt-2">
-                                                    Updated {formatDateTime(item.updatedAt)}
+                                                    {t('issuesAdmin.labels.updated')} {formatDateTime(item.updatedAt)}
                                                 </p>
                                             )}
                                         </div>
@@ -295,7 +299,7 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                                             className={`${requestCardActionBtnClass} border border-border text-muted hover:bg-white/5 hover:text-text`}
                                         >
                                             <MessageSquare className="w-3.5 h-3.5" />
-                                            Comment
+                                            {t('issues.comment')}
                                         </button>
                                         {isOpen ? (
                                             <button
@@ -305,7 +309,7 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                                                 className={`${requestCardActionBtnClass} border border-green-500/30 text-green-300 hover:bg-green-500/10`}
                                             >
                                                 {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Check className="w-3.5 h-3.5" />}
-                                                Resolve
+                                                {t('issues.resolve')}
                                             </button>
                                         ) : (
                                             <button
@@ -315,7 +319,7 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                                                 className={`${requestCardActionBtnClass} border border-plex/30 text-plex hover:bg-plex/10`}
                                             >
                                                 {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <RotateCcw className="w-3.5 h-3.5" />}
-                                                Reopen
+                                                {t('issues.reopen')}
                                             </button>
                                         )}
                                         <button
@@ -325,7 +329,7 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                                             className={`${requestCardActionBtnClass} border border-red-500/30 text-red-300 hover:bg-red-500/10`}
                                         >
                                             <Trash2 className="w-3.5 h-3.5" />
-                                            Delete
+                                            {t('common.delete')}
                                         </button>
                                         {item.tmdbId && (
                                             <a
@@ -333,7 +337,7 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                                                 className={`${requestCardActionBtnClass} border border-border text-muted hover:bg-white/5 hover:text-text no-underline`}
                                             >
                                                 {item.type === 'tv' ? <Tv className="w-3.5 h-3.5" /> : <Film className="w-3.5 h-3.5" />}
-                                                View
+                                                {t('common.view')}
                                             </a>
                                         )}
                                     </RequestCardActions>
@@ -348,12 +352,12 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                 <div className="fixed inset-0 z-[210] flex items-center justify-center p-4">
                     <button
                         type="button"
-                        aria-label="Close"
+                        aria-label={t('common.close')}
                         className="absolute inset-0 bg-black/80 backdrop-blur-sm"
                         onClick={() => { if (actionId == null) setCommentTarget(null); }}
                     />
                     <div className="relative w-full max-w-md rounded-2xl border border-border bg-card p-6 shadow-2xl">
-                        <h3 className="text-lg font-bold text-text mb-2">Reply to issue</h3>
+                        <h3 className="text-lg font-bold text-text mb-2">{t('issuesAdmin.dialogs.replyTitle')}</h3>
                         <p className="text-sm text-muted mb-4">
                             {commentTarget.title} · {commentTarget.createdBy.displayName}
                         </p>
@@ -362,7 +366,7 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                             onChange={(e) => setCommentText(e.target.value)}
                             rows={4}
                             className="w-full rounded-xl border border-border bg-background px-3 py-2.5 text-sm text-text outline-none focus:border-plex focus:ring-1 focus:ring-plex resize-y min-h-[6rem] mb-4"
-                            placeholder="Reply to the user…"
+                            placeholder={t('issuesAdmin.dialogs.replyPlaceholder')}
                         />
                         <div className="flex gap-3">
                             <button
@@ -371,7 +375,7 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                                 onClick={() => setCommentTarget(null)}
                                 className="flex-1 py-2.5 rounded-xl border border-border text-muted font-semibold hover:bg-white/5 transition-colors disabled:opacity-50"
                             >
-                                Cancel
+                                {t('common.cancel')}
                             </button>
                             <button
                                 type="button"
@@ -379,7 +383,7 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                                 onClick={handleComment}
                                 className="flex-1 py-2.5 rounded-xl bg-plex text-black font-bold hover:bg-plex-hover transition-colors disabled:opacity-50"
                             >
-                                {actionId != null ? 'Sending…' : 'Send Reply'}
+                                {actionId != null ? t('issues.sending') : t('issuesAdmin.actions.sendReply')}
                             </button>
                         </div>
                     </div>
@@ -390,14 +394,14 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                 <div className="fixed inset-0 z-[210] flex items-center justify-center p-4">
                     <button
                         type="button"
-                        aria-label="Close"
+                        aria-label={t('common.close')}
                         className="absolute inset-0 bg-black/80 backdrop-blur-sm"
                         onClick={() => { if (actionId == null) setDeleteTarget(null); }}
                     />
                     <div className="relative w-full max-w-md rounded-2xl border border-border bg-card p-6 shadow-2xl">
-                        <h3 className="text-lg font-bold text-text mb-2">Delete issue?</h3>
+                        <h3 className="text-lg font-bold text-text mb-2">{t('issues.deleteTitle')}</h3>
                         <p className="text-sm text-muted mb-5">
-                            Permanently delete the issue for <span className="text-text font-semibold">{deleteTarget.title}</span>?
+                            {t('issuesAdmin.dialogs.deleteBody', { title: deleteTarget.title })}
                         </p>
                         <div className="flex gap-3">
                             <button
@@ -406,7 +410,7 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                                 onClick={() => setDeleteTarget(null)}
                                 className="flex-1 py-2.5 rounded-xl border border-border text-muted font-semibold hover:bg-white/5 transition-colors disabled:opacity-50"
                             >
-                                Cancel
+                                {t('common.cancel')}
                             </button>
                             <button
                                 type="button"
@@ -414,7 +418,7 @@ export const IssuesAdminPanel: React.FC<{ onCountsChange?: () => void }> = ({ on
                                 onClick={handleDelete}
                                 className="flex-1 py-2.5 rounded-xl bg-red-500 text-white font-bold hover:bg-red-600 transition-colors disabled:opacity-50"
                             >
-                                {actionId != null ? 'Deleting…' : 'Delete Issue'}
+                                {actionId != null ? t('issuesAdmin.actions.deleting') : t('issuesAdmin.actions.deleteIssue')}
                             </button>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary

Localizes the Requests admin Issues panel using the existing i18n architecture.

### Included

- Issues page heading and connection summary
- open/resolved filters
- Refresh and Open Seerr actions
- empty states and helper text
- media type and relative-time labels
- comment, resolve, reopen, delete and view actions
- reply and delete dialogs
- local fallback errors and toasts
- loading, deleting and sending states
- related ARIA labels

## Architecture

- uses the existing `useDiscoverI18n()` / `t(...)` flow
- adds a dedicated `issuesAdmin.*` namespace
- reuses existing `common.*`, `issues.*`, `mediaType.*`, and relative-time keys where appropriate
- preserves backend/API-provided messages
- keeps issue IDs, statuses, metadata, routes and service data unchanged

## Validation

- `npm test`: 58 passed
- `npm run build:js`: passed
- `git diff --check`: passed
- EN/FR catalog parity: 1377 / 1377
- 26 new Issues admin keys in each locale
- no missing keys
- no extra keys
- no placeholder mismatches

## Scope

No Requests queue, approval modal, Support tickets, Users, analytics, Settings, or unrelated modules were changed.