### PR TITLE
feat(i18n): expand supported locale infrastructure

### DIFF
--- a/client/discovery/i18n/index.tsx
+++ b/client/discovery/i18n/index.tsx
@@ -4,6 +4,12 @@ import { en } from './en';
 import { fr } from './fr';
 import { de } from './de';
 import { es } from './es';
+import { ptBR } from './pt-BR';
+import { it } from './it';
+import { ja } from './ja';
+import { pl } from './pl';
+import { nl } from './nl';
+import { ru } from './ru';
 import {
     detectDiscoverBrowserLocale,
     isDiscoverLocale,
@@ -15,7 +21,7 @@ import {
     type DiscoverTranslateVars,
 } from './types';
 
-const catalogs: Record<DiscoverLocale, unknown> = { en, fr, de, es };
+const catalogs: Record<DiscoverLocale, unknown> = { en, fr, de, es, 'pt-BR': ptBR, it, ja, pl, nl, ru };
 
 const getPath = (obj: unknown, path: string): unknown => {
     let current: unknown = obj;

--- a/client/discovery/i18n/it.ts
+++ b/client/discovery/i18n/it.ts
@@ -1,0 +1,4 @@
+import type { EnCatalog } from './en';
+
+/** Italian UI overlay. Falls back to English for missing keys. */
+export const it: DeepPartial<EnCatalog> = {};

--- a/client/discovery/i18n/ja.ts
+++ b/client/discovery/i18n/ja.ts
@@ -1,0 +1,4 @@
+import type { EnCatalog } from './en';
+
+/** Japanese UI overlay. Falls back to English for missing keys. */
+export const ja: DeepPartial<EnCatalog> = {};

--- a/client/discovery/i18n/localeInfrastructure.test.js
+++ b/client/discovery/i18n/localeInfrastructure.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { transformSync } from 'esbuild';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import { normalizeDiscoverMetadataLanguage } from '../../../lib/discovery-settings.js';
+
+const loadTypes = () => {
+    const source = fs.readFileSync(new URL('./types.ts', import.meta.url), 'utf8');
+    const code = transformSync(source, { loader: 'ts', format: 'cjs', target: 'es2020' }).code;
+    const module = { exports: {} };
+    vm.runInNewContext(`(function(module){${code}\n})(module)`, { module });
+    return module.exports;
+};
+
+test('supported locale matching preserves regional Brazilian Portuguese', () => {
+    const { matchDiscoverLocale, normalizeDiscoverLocale } = loadTypes();
+    assert.equal(matchDiscoverLocale('it-IT'), 'it');
+    assert.equal(matchDiscoverLocale('ja-JP'), 'ja');
+    assert.equal(matchDiscoverLocale('pl-PL'), 'pl');
+    assert.equal(matchDiscoverLocale('nl-NL'), 'nl');
+    assert.equal(matchDiscoverLocale('ru-RU'), 'ru');
+    assert.equal(matchDiscoverLocale('pt-BR'), 'pt-BR');
+    assert.equal(matchDiscoverLocale('pt-PT'), null);
+    assert.equal(normalizeDiscoverLocale('unsupported'), 'en');
+});
+
+test('metadata locale normalization supports all registered locales', () => {
+    for (const locale of ['en', 'fr', 'de', 'es', 'it', 'ja', 'pl', 'nl', 'ru']) {
+        assert.equal(normalizeDiscoverMetadataLanguage(locale), locale);
+    }
+    assert.equal(normalizeDiscoverMetadataLanguage('pt-BR'), 'pt-BR');
+    assert.equal(normalizeDiscoverMetadataLanguage('pt-PT'), 'en');
+    assert.equal(normalizeDiscoverMetadataLanguage('xx-YY'), 'en');
+});

--- a/client/discovery/i18n/nl.ts
+++ b/client/discovery/i18n/nl.ts
@@ -1,0 +1,4 @@
+import type { EnCatalog } from './en';
+
+/** Dutch UI overlay. Falls back to English for missing keys. */
+export const nl: DeepPartial<EnCatalog> = {};

--- a/client/discovery/i18n/pl.ts
+++ b/client/discovery/i18n/pl.ts
@@ -1,0 +1,4 @@
+import type { EnCatalog } from './en';
+
+/** Polish UI overlay. Falls back to English for missing keys. */
+export const pl: DeepPartial<EnCatalog> = {};

--- a/client/discovery/i18n/pt-BR.ts
+++ b/client/discovery/i18n/pt-BR.ts
@@ -1,0 +1,4 @@
+import type { EnCatalog } from './en';
+
+/** Brazilian Portuguese UI overlay. Falls back to English for missing keys. */
+export const ptBR: DeepPartial<EnCatalog> = {};

--- a/client/discovery/i18n/ru.ts
+++ b/client/discovery/i18n/ru.ts
@@ -1,0 +1,4 @@
+import type { EnCatalog } from './en';
+
+/** Russian UI overlay. Falls back to English for missing keys. */
+export const ru: DeepPartial<EnCatalog> = {};

--- a/client/discovery/i18n/types.ts
+++ b/client/discovery/i18n/types.ts
@@ -3,6 +3,12 @@ export const DISCOVER_LOCALES = [
     { code: 'fr', label: 'French', nativeLabel: 'Français' },
     { code: 'de', label: 'German', nativeLabel: 'Deutsch' },
     { code: 'es', label: 'Spanish', nativeLabel: 'Español' },
+    { code: 'pt-BR', label: 'Portuguese (Brazil)', nativeLabel: 'Português (Brasil)' },
+    { code: 'it', label: 'Italian', nativeLabel: 'Italiano' },
+    { code: 'ja', label: 'Japanese', nativeLabel: '日本語' },
+    { code: 'pl', label: 'Polish', nativeLabel: 'Polski' },
+    { code: 'nl', label: 'Dutch', nativeLabel: 'Nederlands' },
+    { code: 'ru', label: 'Russian', nativeLabel: 'Русский' },
 ] as const;
 
 export type DiscoverLocale = (typeof DISCOVER_LOCALES)[number]['code'];
@@ -22,7 +28,7 @@ export const isDiscoverLocale = (value: unknown): value is DiscoverLocale => (
 export const matchDiscoverLocale = (value: unknown): DiscoverLocale | null => {
     const raw = String(value || '').trim().toLowerCase().replace(/_/g, '-');
     if (!raw) return null;
-    const exact = DISCOVER_LOCALES.find((locale) => locale.code === raw);
+    const exact = DISCOVER_LOCALES.find((locale) => locale.code.toLowerCase() === raw);
     if (exact) return exact.code;
     const base = raw.split('-')[0];
     return DISCOVER_LOCALES.find((locale) => locale.code === base)?.code || null;

--- a/docs/development/translation-status.md
+++ b/docs/development/translation-status.md
@@ -4,6 +4,8 @@ This is a living planning document. Re-audit the current `nightly` branch before
 
 This file tracks UI i18n wiring and known remaining localization work. It does not guarantee translation completeness for every individual locale.
 
+The supported UI locale set is `en`, `fr`, `de`, `es`, `pt-BR`, `it`, `ja`, `pl`, `nl`, and `ru`. English is the source catalog; French is currently complete, German and Spanish are partial overlays, and the six newly registered locales are partial overlays that fall back to English.
+
 ## Status Meaning
 
 | State | Meaning |

--- a/docs/development/translations.md
+++ b/docs/development/translations.md
@@ -2,7 +2,7 @@
 
 This guide explains how to contribute UI translations to Server Manager Portal.
 
-It applies to French, German, Spanish, existing locales, and future locales. Keep translation changes focused, reviewable, and aligned with the project's current localization architecture.
+It applies to French, German, Spanish, Portuguese (Brazil), Italian, Japanese, Polish, Dutch, Russian, and future locales. Keep translation changes focused, reviewable, and aligned with the project's current localization architecture.
 
 ## Localization Architecture
 
@@ -11,7 +11,7 @@ Most translated UI chrome uses the Discover i18n system:
 | File / API | Purpose |
 | --- | --- |
 | `client/discovery/i18n/en.ts` | Source catalog. English strings live here first. |
-| `client/discovery/i18n/fr.ts`, `de.ts`, `es.ts` | Locale overlays. These mirror English keys where translated strings exist. |
+| `client/discovery/i18n/fr.ts`, `de.ts`, `es.ts`, and additional locale files | Locale overlays. These may be partial and mirror English keys where translated strings exist. |
 | `client/discovery/i18n/types.ts` | Supported locale metadata for the language menu. |
 | `client/discovery/i18n/index.tsx` | Catalog registry, provider, and translation helper. |
 | `DiscoverI18nProvider` | React provider for the active UI locale. |
@@ -19,6 +19,8 @@ Most translated UI chrome uses the Discover i18n system:
 | `t('dot.path')` | Translation lookup helper. |
 
 English is the source catalog. Missing locale keys fall back to English, so partially translated locales remain usable.
+
+The current supported UI locales are `en`, `fr`, `de`, `es`, `pt-BR`, `it`, `ja`, `pl`, `nl`, and `ru`. `pt-BR` is a regional locale and must remain distinct from generic Portuguese. The newly registered locale overlays may be partial; registration does not imply complete translation coverage.
 
 Do not introduce another global localization system. When adding localized UI chrome to the wider portal, prefer extending the existing Discover catalogs and wiring the UI through `useDiscoverI18n()` / `t(...)`.
 

--- a/index.js
+++ b/index.js
@@ -3824,11 +3824,12 @@ app.post('/api/users/preferences', requireAuth, requireMember, async (req, res) 
             }
         }
         if (uiLocale !== undefined) {
-            const normalizedLocale = String(uiLocale || '').trim().toLowerCase();
-            if (!['en', 'fr', 'de', 'es'].includes(normalizedLocale)) {
+            const normalizedLocale = String(uiLocale || '').trim().toLowerCase().replace(/_/g, '-');
+            const persistedLocale = normalizedLocale === 'pt-br' ? 'pt-BR' : normalizedLocale;
+            if (!['en', 'fr', 'de', 'es', 'pt-BR', 'it', 'ja', 'pl', 'nl', 'ru'].includes(persistedLocale)) {
                 return res.status(400).json({ error: 'Unsupported locale' });
             }
-            users[userIndex].uiLocale = normalizedLocale;
+            users[userIndex].uiLocale = persistedLocale;
         }
         const boolPrefs = {
             notifyRequestAvailableEmail,

--- a/lib/discovery-settings.js
+++ b/lib/discovery-settings.js
@@ -114,12 +114,14 @@ export const getDiscoveryPreferences = (config = {}) => ({
     nowPlayingEnabled: config.discoverNowPlayingEnabled !== false,
 });
 
-const DISCOVER_METADATA_LOCALES = new Set(['en', 'fr', 'de', 'es']);
+const DISCOVER_METADATA_LOCALES = new Set(['en', 'fr', 'de', 'es', 'pt-br', 'it', 'ja', 'pl', 'nl', 'ru']);
 
 /** Normalize portal UI locale → TMDB/Seerr metadata language (en/fr/de/es). */
 export const normalizeDiscoverMetadataLanguage = (value) => {
-    const code = String(value || '').trim().toLowerCase().split(/[-_]/)[0];
-    return DISCOVER_METADATA_LOCALES.has(code) ? code : 'en';
+    const code = String(value || '').trim().toLowerCase().replace(/_/g, '-');
+    if (code === 'pt-br') return 'pt-BR';
+    const base = code.split('-')[0];
+    return DISCOVER_METADATA_LOCALES.has(base) ? base : 'en';
 };
 
 export const resolveDiscoverMetadataLanguage = (req) => {


### PR DESCRIPTION
## Summary

Expands the existing locale infrastructure from 4 supported UI locales to 10 while preserving the current Discover i18n architecture and English fallback behavior.

### Added locales

- `pt-BR` — Português (Brasil)
- `it` — Italiano
- `ja` — 日本語
- `pl` — Polski
- `nl` — Nederlands
- `ru` — Русский

Existing locales remain unchanged:

- `en`
- `fr`
- `de`
- `es`

## Architecture

- extends the existing `DISCOVER_LOCALES` / `DiscoverLocale` source of truth
- registers six new `DeepPartial<EnCatalog>` locale overlays
- preserves English as the fallback catalog
- keeps account locale > localStorage > browser locale > English precedence unchanged
- preserves locale values through Preferences, account storage, session responses, and metadata requests
- does not introduce a new i18n provider or translation system

## Regional locale handling

- `pt-BR` is treated as an explicit supported regional locale
- `pt-BR` remains preserved end-to-end instead of being reduced to `pt`
- `pt-PT` remains unsupported and falls back to English
- regional matching continues to support locales such as `it-IT`, `ja-JP`, `pl-PL`, `nl-NL`, and `ru-RU`

## Backend

- expands the `uiLocale` validation allowlist to all 10 supported locales
- updates metadata locale normalization
- keeps the existing `users.json` storage format unchanged
- no migration is required

## Translation coverage

This PR only registers the new locales and infrastructure.

The new locale overlays are intentionally partial/empty and rely on the existing English fallback behavior. It does not claim full translation coverage for the six newly supported locales.

Existing German and Spanish partial-overlay behavior remains unchanged.

## Tests

Added focused locale infrastructure coverage for:

- new locale matching
- regional locale matching
- `pt-BR`
- `pt-PT` fallback
- unsupported locale fallback
- metadata locale normalization

## Validation

- `npm test`: 58 passed
- focused locale infrastructure tests: passed
- `npm run build:js`: passed
- `npm run docs:build`: passed
- `git diff --check`: passed

## Documentation

Updated:

- `docs/development/translations.md`
- `docs/development/translation-status.md`

to document the 10 supported locales, partial overlays, English fallback, and `pt-BR` regional handling.

## Scope

This PR only changes locale registration, detection, validation, fallback behavior, focused tests, and translation documentation.

No feature localization, pluralization redesign, database migration, or unrelated UI behavior is included.