### PR TITLE
feat(i18n): localize Settings logs and audit

### DIFF
--- a/client/discovery/i18n/de.ts
+++ b/client/discovery/i18n/de.ts
@@ -458,6 +458,15 @@ Object.assign(de, { maintenance: { ...de.maintenance,
     calendar: { currentRule: 'Aktuelle Regel:', graceDays: 'Karenztage', ruleAge: 'Regelalter', eligibleNow: 'Jetzt berechtigt', laterReclaim: 'Spätere Rückgewinnung', daysUntilEligible: 'Tag(e) bis zur Berechtigung', titleCount: 'Titel', laterDetail: 'Diese Titel warten noch auf das Ende der Karenzzeit.', dateTitleCount: 'Anzahl der Titel für dieses Datum.', delayedReclaimTooltip: 'Schätzung der Rückgewinnung aus verzögerten Treffern.', eligibilityDetailTooltip: 'Berechtigungsdetails des Backends.', ago: 'Tage zuvor', notAvailable: 'n/v', ...de.maintenance.calendar }
 } });
 
+Object.assign(de, { settings: { ...de.settings, logs: {
+    actions: { refresh: 'Aktualisieren', refreshing: 'Aktualisierung...', exportAll: 'Alles exportieren', exporting: 'Export wird erstellt…', unblock: 'Entsperren' },
+    audit: { viewerTitle: 'Auditprotokollanzeige', empty: 'Keine Audit-Ereignisse gefunden.', target: 'Ziel', system: 'System', actor: 'Akteur', field: 'Feld', before: 'Vorher', after: 'Nachher', value: 'Wert', unknownEvent: 'Ereignis' },
+    blocklist: { title: 'Sperrliste gelöschter Benutzer', empty: 'Derzeit sind keine gelöschten Benutzer gesperrt.', unknownUser: 'Unbekannter Benutzer', noIdentifier: 'Keine Kennung', deletedBy: 'Gelöscht am {date} von {actor}', defaultActor: 'Administrator' },
+    email: { title: 'E-Mail-Protokoll', empty: 'Es wurden noch keine System-E-Mails protokolliert.', systemEmail: 'System-E-Mail', to: 'An' },
+    pagination: { previous: 'Zurück', next: 'Weiter', pageOf: 'Seite {page} von {total}' }, dialogs: { unblockUser: '{name} wieder für das Portal zulassen? Dadurch wird keine Einladung automatisch gesendet.' }, fallbacks: { thisUser: 'dieser Benutzer', notAvailable: 'N/V' },
+    errors: { loadAuditLog: 'Auditprotokoll konnte nicht geladen werden', exportAuditLog: 'Auditprotokoll konnte nicht exportiert werden', loadDeletedUsers: 'Protokoll gelöschter Benutzer konnte nicht geladen werden', unblockUser: 'Benutzer konnte nicht entsperrt werden.' }, toasts: { auditExported: 'Auditprotokoll exportiert (Portal + Poster Sets + Upgrader).', userUnblocked: 'Gelöschter Benutzer entsperrt.' },
+} } });
+
 Object.assign(de, { maintenance: { ...de.maintenance,
     ...de.maintenance,
     page: { title: 'Cleaner', disabledTitle: 'Cleaner deaktiviert', disabledDescription: 'Der experimentelle Reinigungsmodus ist derzeit AUS.', disabledHint: 'Aktivieren Sie ihn unter `Einstellungen` → `System` bei `Experimenteller Reinigungsmodus` und klicken Sie auf Einstellungen speichern.', controlCenter: 'Cleaner-Kontrollzentrum', controlCenterDescription: 'Modul für die automatisierte Bibliothekswartung: Regeln, Sammlungen, Kandidaten, Ausführungszeitplan, Kalender, Speicher und Verwaltung.' },

--- a/client/discovery/i18n/en.ts
+++ b/client/discovery/i18n/en.ts
@@ -1173,6 +1173,17 @@ export const en = {
             sentTo: 'Sent to: {email}',
             revoke: 'Revoke',
         },
+        logs: {
+            actions: { refresh: 'Refresh', refreshing: 'Refreshing...', exportAll: 'Export all', exporting: 'Exporting…', unblock: 'Unblock' },
+            audit: { viewerTitle: 'Audit Log Viewer', empty: 'No audit events found.', target: 'Target', system: 'System', actor: 'Actor', field: 'Field', before: 'Before', after: 'After', value: 'Value', unknownEvent: 'Event' },
+            blocklist: { title: 'Deleted User Blocklist', empty: 'No deleted users are currently blocked.', unknownUser: 'Unknown user', noIdentifier: 'No identifier', deletedBy: 'Deleted {date} by {actor}', defaultActor: 'admin' },
+            email: { title: 'Email Log', empty: 'No system emails have been logged yet.', systemEmail: 'System Email', to: 'To' },
+            pagination: { previous: 'Previous', next: 'Next', pageOf: 'Page {page} of {total}' },
+            dialogs: { unblockUser: 'Allow {name} to use the portal again? This does not invite them automatically.' },
+            fallbacks: { thisUser: 'this user', notAvailable: 'N/A' },
+            errors: { loadAuditLog: 'Failed to load audit log', exportAuditLog: 'Failed to export audit log', loadDeletedUsers: 'Failed to load deleted users log', unblockUser: 'Failed to unblock user.' },
+            toasts: { auditExported: 'Audit log exported (portal + Poster Sets + Upgrader).', userUnblocked: 'Deleted user unblocked.' },
+        },
         navigation: {
             category: 'Settings Category',
             noSections: 'No settings sections found.',

--- a/client/discovery/i18n/es.ts
+++ b/client/discovery/i18n/es.ts
@@ -462,6 +462,15 @@ Object.assign(es, { maintenance: { ...es.maintenance,
     errors: { loadOverview: 'No se pudo cargar el resumen de limpieza', loadCandidates: 'No se pudieron cargar los candidatos', loadExclusions: 'No se pudo cargar el resumen de exclusiones.', loadLibrary: 'No se pudieron cargar los pósteres de la biblioteca.', loadStorage: 'No se pudo cargar el resumen de almacenamiento.' }
 } });
 
+Object.assign(es, { settings: { ...es.settings, logs: {
+    actions: { refresh: 'Actualizar', refreshing: 'Actualizando...', exportAll: 'Exportar todo', exporting: 'Exportando…', unblock: 'Desbloquear' },
+    audit: { viewerTitle: 'Visor del registro de auditoría', empty: 'No se encontraron eventos de auditoría.', target: 'Destino', system: 'Sistema', actor: 'Autor', field: 'Campo', before: 'Antes', after: 'Después', value: 'Valor', unknownEvent: 'Evento' },
+    blocklist: { title: 'Lista de bloqueo de usuarios eliminados', empty: 'No hay usuarios eliminados bloqueados actualmente.', unknownUser: 'Usuario desconocido', noIdentifier: 'Sin identificador', deletedBy: 'Eliminado el {date} por {actor}', defaultActor: 'administrador' },
+    email: { title: 'Registro de correo electrónico', empty: 'Aún no se han registrado correos electrónicos del sistema.', systemEmail: 'Correo electrónico del sistema', to: 'Para' },
+    pagination: { previous: 'Anterior', next: 'Siguiente', pageOf: 'Página {page} de {total}' }, dialogs: { unblockUser: '¿Permitir que {name} vuelva a usar el portal? Esto no le envía una invitación automáticamente.' }, fallbacks: { thisUser: 'este usuario', notAvailable: 'N/D' },
+    errors: { loadAuditLog: 'No se pudo cargar el registro de auditoría', exportAuditLog: 'No se pudo exportar el registro de auditoría', loadDeletedUsers: 'No se pudo cargar el registro de usuarios eliminados', unblockUser: 'No se pudo desbloquear al usuario.' }, toasts: { auditExported: 'Registro de auditoría exportado (portal + Poster Sets + Upgrader).', userUnblocked: 'Usuario eliminado desbloqueado.' },
+} } });
+
 Object.assign(es, { maintenance: { ...es.maintenance,
     ...es.maintenance,
     sections: { overview: 'Resumen', exclusions: 'Exclusiones', rules: 'Reglas', collections: 'Colecciones', candidates: 'Candidatos', calendar: 'Calendario', storage: 'Métricas de almacenamiento', library: 'Biblioteca de reglas', settings: 'Ajustes de limpieza', logs: 'Registros' },

--- a/client/discovery/i18n/fr.ts
+++ b/client/discovery/i18n/fr.ts
@@ -1769,6 +1769,15 @@ Object.assign(fr, { maintenance: {
             errors: { ...fr.maintenance.errors, loadOverview: 'Impossible de charger la vue d’ensemble du nettoyage', loadCandidates: 'Impossible de charger les candidats', loadExclusions: 'Impossible de charger le résumé des exclusions.', loadLibrary: 'Impossible de charger les affiches de la bibliothèque.', loadStorage: 'Impossible de charger le résumé du stockage.' }
 } });
 
+Object.assign(fr, { settings: { ...fr.settings, logs: {
+    actions: { refresh: 'Actualiser', refreshing: 'Actualisation...', exportAll: 'Tout exporter', exporting: 'Exportation…', unblock: 'Débloquer' },
+    audit: { viewerTitle: 'Visionneuse du journal d’audit', empty: 'Aucun événement d’audit trouvé.', target: 'Cible', system: 'Système', actor: 'Auteur', field: 'Champ', before: 'Avant', after: 'Après', value: 'Valeur', unknownEvent: 'Événement' },
+    blocklist: { title: 'Liste de blocage des utilisateurs supprimés', empty: 'Aucun utilisateur supprimé n’est actuellement bloqué.', unknownUser: 'Utilisateur inconnu', noIdentifier: 'Aucun identifiant', deletedBy: 'Supprimé le {date} par {actor}', defaultActor: 'administrateur' },
+    email: { title: 'Journal des e-mails', empty: 'Aucun e-mail système n’a encore été enregistré.', systemEmail: 'E-mail système', to: 'À' },
+    pagination: { previous: 'Précédent', next: 'Suivant', pageOf: 'Page {page} sur {total}' }, dialogs: { unblockUser: 'Autoriser {name} à utiliser à nouveau le portail ? Cela ne l’invite pas automatiquement.' }, fallbacks: { thisUser: 'cet utilisateur', notAvailable: 'N/D' },
+    errors: { loadAuditLog: 'Échec du chargement du journal d’audit', exportAuditLog: 'Échec de l’exportation du journal d’audit', loadDeletedUsers: 'Échec du chargement du journal des utilisateurs supprimés', unblockUser: 'Échec du déblocage de l’utilisateur.' }, toasts: { auditExported: 'Journal d’audit exporté (portail + Poster Sets + Upgrader).', userUnblocked: 'Utilisateur supprimé débloqué.' },
+} } });
+
 Object.assign(fr, { maintenance: { ...fr.maintenance,
     ...fr.maintenance,
     labels: { ...fr.maintenance?.labels, unknownTitle: 'Titre inconnu' },

--- a/client/discovery/i18n/it.ts
+++ b/client/discovery/i18n/it.ts
@@ -44,6 +44,15 @@ Object.assign(it, { maintenance: { ...it.maintenance,
     errors: { loadOverview: 'Impossibile caricare il riepilogo della pulizia', loadCandidates: 'Impossibile caricare i candidati', loadExclusions: 'Impossibile caricare il riepilogo delle esclusioni.', loadLibrary: 'Impossibile caricare i poster della libreria.', loadStorage: 'Impossibile caricare il riepilogo dello spazio.' }
 } });
 
+Object.assign(it, { settings: { ...it.settings, logs: {
+    actions: { refresh: 'Aggiorna', refreshing: 'Aggiornamento...', exportAll: 'Esporta tutto', exporting: 'Esportazione…', unblock: 'Sblocca' },
+    audit: { viewerTitle: 'Visualizzatore del registro di controllo', empty: 'Nessun evento di controllo trovato.', target: 'Destinazione', system: 'Sistema', actor: 'Autore', field: 'Campo', before: 'Prima', after: 'Dopo', value: 'Valore', unknownEvent: 'Evento' },
+    blocklist: { title: 'Elenco dei blocchi degli utenti eliminati', empty: 'Al momento non sono presenti utenti eliminati bloccati.', unknownUser: 'Utente sconosciuto', noIdentifier: 'Nessun identificatore', deletedBy: 'Eliminato il {date} da {actor}', defaultActor: 'amministratore' },
+    email: { title: 'Registro e-mail', empty: 'Non sono ancora state registrate e-mail di sistema.', systemEmail: 'E-mail di sistema', to: 'A' },
+    pagination: { previous: 'Precedente', next: 'Successivo', pageOf: 'Pagina {page} di {total}' }, dialogs: { unblockUser: 'Consentire a {name} di usare nuovamente il portale? Non verrà inviato automaticamente un invito.' }, fallbacks: { thisUser: 'questo utente', notAvailable: 'N/D' },
+    errors: { loadAuditLog: 'Impossibile caricare il registro di controllo', exportAuditLog: 'Impossibile esportare il registro di controllo', loadDeletedUsers: 'Impossibile caricare il registro degli utenti eliminati', unblockUser: 'Impossibile sbloccare l’utente.' }, toasts: { auditExported: 'Registro di controllo esportato (portale + Poster Sets + Upgrader).', userUnblocked: 'Utente eliminato sbloccato.' },
+} } });
+
 Object.assign(it, { maintenance: {
     ...it.maintenance,
     labels: { ...it.maintenance.labels, true: 'Vero', false: 'Falso', minMax: 'min,max', values: 'v1,v2', value: 'valore', enabled: 'Attivato', disabled: 'Disattivato', matches: 'Corrispondenze', grace: 'Periodo di grazia', graceDays: 'Giorni di grazia', maxActions: 'Azioni massime', collectionName: 'Nome raccolta', matchLogic: 'Logica corrispondenza', filterName: 'Nome filtro', matchedTitles: 'Titoli corrispondenti', noPoster: 'Nessun poster', eligible: 'Idoneo', unmapped: 'Non associato', ambiguous: 'Ambiguo', ...it.maintenance?.labels, mapped: 'associati', instanceMappingHint: 'Mappatura dell’istanza ambigua', index: 'Indice', mediaItems: 'elementi multimediali', lastBuild: 'Ultima ricostruzione', requestRecords: 'Record delle richieste',...it.maintenance?.labels, matchLogicHint: 'Come vengono combinate le condizioni della regola.', graceHint: 'Periodo di grazia globale per questo insieme di regole.', resetGraceHint: 'Reimposta ora il periodo di grazia di questa regola.' },

--- a/client/discovery/i18n/ja.ts
+++ b/client/discovery/i18n/ja.ts
@@ -44,6 +44,15 @@ Object.assign(ja, { maintenance: { ...ja.maintenance,
     errors: { loadOverview: 'クリーナー概要を読み込めませんでした', loadCandidates: '候補を読み込めませんでした', loadExclusions: '除外の概要を読み込めませんでした。', loadLibrary: 'ライブラリのポスターを読み込めませんでした。', loadStorage: 'ストレージ概要を読み込めませんでした。' }
 } });
 
+Object.assign(ja, { settings: { ...ja.settings, logs: {
+    actions: { refresh: '更新', refreshing: '更新中...', exportAll: 'すべてエクスポート', exporting: 'エクスポート中…', unblock: 'ブロック解除' },
+    audit: { viewerTitle: '監査ログビューアー', empty: '監査イベントが見つかりません。', target: '対象', system: 'システム', actor: '実行者', field: '項目', before: '変更前', after: '変更後', value: '値', unknownEvent: 'イベント' },
+    blocklist: { title: '削除済みユーザーのブロックリスト', empty: '現在ブロックされている削除済みユーザーはいません。', unknownUser: '不明なユーザー', noIdentifier: '識別子なし', deletedBy: '{actor} が {date} に削除', defaultActor: '管理者' },
+    email: { title: 'メールログ', empty: 'システムメールはまだ記録されていません。', systemEmail: 'システムメール', to: '宛先' },
+    pagination: { previous: '前へ', next: '次へ', pageOf: '{total} ページ中 {page} ページ' }, dialogs: { unblockUser: '{name} が再びポータルを使用できるようにしますか？自動的に招待されることはありません。' }, fallbacks: { thisUser: 'このユーザー', notAvailable: '該当なし' },
+    errors: { loadAuditLog: '監査ログを読み込めませんでした', exportAuditLog: '監査ログをエクスポートできませんでした', loadDeletedUsers: '削除済みユーザーのログを読み込めませんでした', unblockUser: 'ユーザーのブロックを解除できませんでした。' }, toasts: { auditExported: '監査ログをエクスポートしました（ポータル + Poster Sets + Upgrader）。', userUnblocked: '削除済みユーザーのブロックを解除しました。' },
+} } });
+
 Object.assign(ja, { maintenance: {
     ...ja.maintenance,
     labels: { ...ja.maintenance.labels, true: '真', false: '偽', minMax: '最小,最大', values: 'v1,v2', value: '値', enabled: '有効', disabled: '無効', matches: '一致', grace: '猶予期間', graceDays: '猶予日数', maxActions: '最大アクション数', collectionName: 'コレクション名', matchLogic: '一致条件', filterName: 'フィルター名', matchedTitles: '一致したタイトル', noPoster: 'ポスターなし', eligible: '対象', unmapped: '未マッピング', ambiguous: '不明確', ...ja.maintenance?.labels, mapped: 'マッピング済み', instanceMappingHint: 'インスタンスのマッピングが不明確です', index: 'インデックス', mediaItems: 'メディア項目', lastBuild: '最終構築', requestRecords: 'リクエスト記録',...ja.maintenance?.labels, matchLogicHint: 'ルール条件の組み合わせ方。', graceHint: 'このルールセットの全体猶予期間。', resetGraceHint: 'このルールの猶予タイマーを今すぐリセットします。' },

--- a/client/discovery/i18n/nl.ts
+++ b/client/discovery/i18n/nl.ts
@@ -44,6 +44,15 @@ Object.assign(nl, { maintenance: { ...nl.maintenance,
     errors: { loadOverview: 'Overzicht van opschonen kon niet worden geladen', loadCandidates: 'Kandidaten konden niet worden geladen', loadExclusions: 'Samenvatting van uitsluitingen kon niet worden geladen.', loadLibrary: 'Bibliotheekposters konden niet worden geladen.', loadStorage: 'Opslagsamenvatting kon niet worden geladen.' }
 } });
 
+Object.assign(nl, { settings: { ...nl.settings, logs: {
+    actions: { refresh: 'Vernieuwen', refreshing: 'Vernieuwen...', exportAll: 'Alles exporteren', exporting: 'Exporteren…', unblock: 'Deblokkeren' },
+    audit: { viewerTitle: 'Auditlogviewer', empty: 'Geen auditgebeurtenissen gevonden.', target: 'Doel', system: 'Systeem', actor: 'Uitvoerder', field: 'Veld', before: 'Vóór', after: 'Na', value: 'Waarde', unknownEvent: 'Gebeurtenis' },
+    blocklist: { title: 'Blokkeerlijst voor verwijderde gebruikers', empty: 'Er zijn momenteel geen verwijderde gebruikers geblokkeerd.', unknownUser: 'Onbekende gebruiker', noIdentifier: 'Geen identificatie', deletedBy: 'Verwijderd op {date} door {actor}', defaultActor: 'beheerder' },
+    email: { title: 'E-maillog', empty: 'Er zijn nog geen systeeme-mails geregistreerd.', systemEmail: 'Systeeme-mail', to: 'Aan' },
+    pagination: { previous: 'Vorige', next: 'Volgende', pageOf: 'Pagina {page} van {total}' }, dialogs: { unblockUser: '{name} weer toegang geven tot de portal? Dit verstuurt niet automatisch een uitnodiging.' }, fallbacks: { thisUser: 'deze gebruiker', notAvailable: 'N.v.t.' },
+    errors: { loadAuditLog: 'Auditlog kon niet worden geladen', exportAuditLog: 'Auditlog kon niet worden geëxporteerd', loadDeletedUsers: 'Log van verwijderde gebruikers kon niet worden geladen', unblockUser: 'Gebruiker kon niet worden gedeblokkeerd.' }, toasts: { auditExported: 'Auditlog geëxporteerd (portal + Poster Sets + Upgrader).', userUnblocked: 'Verwijderde gebruiker gedeblokkeerd.' },
+} } });
+
 Object.assign(nl, { maintenance: {
     ...nl.maintenance,
     labels: { ...nl.maintenance.labels, true: 'Waar', false: 'Onwaar', minMax: 'min,max', values: 'v1,v2', value: 'waarde', enabled: 'Ingeschakeld', disabled: 'Uitgeschakeld', matches: 'Overeenkomsten', grace: 'Respijtperiode', graceDays: 'Respijtdagen', maxActions: 'Max. acties', collectionName: 'Collectienaam', matchLogic: 'Overeenkomstlogica', filterName: 'Filternaam', matchedTitles: 'Overeenkomende titels', noPoster: 'Geen poster', eligible: 'In aanmerking komend', unmapped: 'Niet gekoppeld', ambiguous: 'Onduidelijk', ...nl.maintenance?.labels, mapped: 'gekoppeld', instanceMappingHint: 'Onduidelijke instantietoewijzing', index: 'Index', mediaItems: 'media-items', lastBuild: 'Laatste opbouw', requestRecords: 'Aanvraagrecords',...nl.maintenance?.labels, matchLogicHint: 'Hoe regelvoorwaarden worden gecombineerd.', graceHint: 'Algemene respijtperiode voor deze regelset.', resetGraceHint: 'Respijttimer voor deze regel nu resetten.' },

--- a/client/discovery/i18n/pl.ts
+++ b/client/discovery/i18n/pl.ts
@@ -44,6 +44,15 @@ Object.assign(pl, { maintenance: { ...pl.maintenance,
     errors: { loadOverview: 'Nie udało się wczytać przeglądu czyszczenia', loadCandidates: 'Nie udało się wczytać kandydatów', loadExclusions: 'Nie udało się wczytać podsumowania wykluczeń.', loadLibrary: 'Nie udało się wczytać plakatów biblioteki.', loadStorage: 'Nie udało się wczytać podsumowania pamięci.' }
 } });
 
+Object.assign(pl, { settings: { ...pl.settings, logs: {
+    actions: { refresh: 'Odśwież', refreshing: 'Odświeżanie...', exportAll: 'Eksportuj wszystko', exporting: 'Eksportowanie…', unblock: 'Odblokuj' },
+    audit: { viewerTitle: 'Przeglądarka dziennika audytu', empty: 'Nie znaleziono zdarzeń audytu.', target: 'Cel', system: 'System', actor: 'Wykonawca', field: 'Pole', before: 'Przed', after: 'Po', value: 'Wartość', unknownEvent: 'Zdarzenie' },
+    blocklist: { title: 'Lista blokad usuniętych użytkowników', empty: 'Obecnie nie ma zablokowanych usuniętych użytkowników.', unknownUser: 'Nieznany użytkownik', noIdentifier: 'Brak identyfikatora', deletedBy: 'Usunięto {date} przez {actor}', defaultActor: 'administrator' },
+    email: { title: 'Dziennik e-maili', empty: 'Nie zarejestrowano jeszcze żadnych e-maili systemowych.', systemEmail: 'E-mail systemowy', to: 'Do' },
+    pagination: { previous: 'Poprzednia', next: 'Następna', pageOf: 'Strona {page} z {total}' }, dialogs: { unblockUser: 'Zezwolić użytkownikowi {name} ponownie korzystać z portalu? Nie wyśle to automatycznie zaproszenia.' }, fallbacks: { thisUser: 'ten użytkownik', notAvailable: 'Brak danych' },
+    errors: { loadAuditLog: 'Nie udało się wczytać dziennika audytu', exportAuditLog: 'Nie udało się wyeksportować dziennika audytu', loadDeletedUsers: 'Nie udało się wczytać dziennika usuniętych użytkowników', unblockUser: 'Nie udało się odblokować użytkownika.' }, toasts: { auditExported: 'Wyeksportowano dziennik audytu (portal + Poster Sets + Upgrader).', userUnblocked: 'Odblokowano usuniętego użytkownika.' },
+} } });
+
 Object.assign(pl, { maintenance: {
     ...pl.maintenance,
     labels: { ...pl.maintenance.labels, true: 'Prawda', false: 'Fałsz', minMax: 'min,maks', values: 'v1,v2', value: 'wartość', enabled: 'Włączony', disabled: 'Wyłączony', matches: 'Dopasowania', grace: 'Okres karencji', graceDays: 'Dni karencji', maxActions: 'Maks. liczba działań', collectionName: 'Nazwa kolekcji', matchLogic: 'Logika dopasowania', filterName: 'Nazwa filtra', matchedTitles: 'Dopasowane tytuły', noPoster: 'Brak plakatu', eligible: 'Kwalifikuje się', unmapped: 'Nieprzypisane', ambiguous: 'Niejednoznaczne', ...pl.maintenance?.labels, mapped: 'przypisano', instanceMappingHint: 'Niejednoznaczne przypisanie instancji', index: 'Indeks', mediaItems: 'elementów multimedialnych', lastBuild: 'Ostatnia przebudowa', requestRecords: 'Rejestry żądań',...pl.maintenance?.labels, matchLogicHint: 'Sposób łączenia warunków reguły.', graceHint: 'Globalny okres karencji dla tego zestawu reguł.', resetGraceHint: 'Zresetuj teraz okres karencji tej reguły.' },

--- a/client/discovery/i18n/pt-BR.ts
+++ b/client/discovery/i18n/pt-BR.ts
@@ -44,6 +44,15 @@ Object.assign(ptBR, { maintenance: { ...ptBR.maintenance,
     errors: { loadOverview: 'Não foi possível carregar o resumo da limpeza', loadCandidates: 'Não foi possível carregar os candidatos', loadExclusions: 'Não foi possível carregar o resumo das exclusões.', loadLibrary: 'Não foi possível carregar os pôsteres da biblioteca.', loadStorage: 'Não foi possível carregar o resumo do armazenamento.' }
 } });
 
+Object.assign(ptBR, { settings: { ...ptBR.settings, logs: {
+    actions: { refresh: 'Atualizar', refreshing: 'Atualizando...', exportAll: 'Exportar tudo', exporting: 'Exportando…', unblock: 'Desbloquear' },
+    audit: { viewerTitle: 'Visualizador do registro de auditoria', empty: 'Nenhum evento de auditoria encontrado.', target: 'Destino', system: 'Sistema', actor: 'Autor', field: 'Campo', before: 'Antes', after: 'Depois', value: 'Valor', unknownEvent: 'Evento' },
+    blocklist: { title: 'Lista de bloqueio de usuários excluídos', empty: 'Não há usuários excluídos bloqueados no momento.', unknownUser: 'Usuário desconhecido', noIdentifier: 'Sem identificador', deletedBy: 'Excluído em {date} por {actor}', defaultActor: 'administrador' },
+    email: { title: 'Registro de e-mails', empty: 'Ainda não foram registrados e-mails do sistema.', systemEmail: 'E-mail do sistema', to: 'Para' },
+    pagination: { previous: 'Anterior', next: 'Próxima', pageOf: 'Página {page} de {total}' }, dialogs: { unblockUser: 'Permitir que {name} use o portal novamente? Isso não envia um convite automaticamente.' }, fallbacks: { thisUser: 'este usuário', notAvailable: 'N/D' },
+    errors: { loadAuditLog: 'Não foi possível carregar o registro de auditoria', exportAuditLog: 'Não foi possível exportar o registro de auditoria', loadDeletedUsers: 'Não foi possível carregar o registro de usuários excluídos', unblockUser: 'Não foi possível desbloquear o usuário.' }, toasts: { auditExported: 'Registro de auditoria exportado (portal + Poster Sets + Upgrader).', userUnblocked: 'Usuário excluído desbloqueado.' },
+} } });
+
 Object.assign(ptBR, { maintenance: {
     ...ptBR.maintenance,
     labels: { ...ptBR.maintenance.labels, true: 'Verdadeiro', false: 'Falso', minMax: 'mín,máx', values: 'v1,v2', value: 'valor', enabled: 'Ativado', disabled: 'Desativado', matches: 'Correspondências', grace: 'Período de carência', graceDays: 'Dias de carência', maxActions: 'Máximo de ações', collectionName: 'Nome da coleção', matchLogic: 'Lógica de correspondência', filterName: 'Nome do filtro', matchedTitles: 'Títulos correspondentes', noPoster: 'Sem pôster', eligible: 'Elegível', unmapped: 'Não mapeado', ambiguous: 'Ambíguo', ...ptBR.maintenance?.labels, mapped: 'mapeados', instanceMappingHint: 'Mapeamento de instância ambíguo', index: 'Índice', mediaItems: 'itens de mídia', lastBuild: 'Última reconstrução', requestRecords: 'Registros de solicitações',...ptBR.maintenance?.labels, matchLogicHint: 'Como as condições da regra são combinadas.', graceHint: 'Período de carência global para este conjunto de regras.', resetGraceHint: 'Redefinir agora o período de carência desta regra.' },

--- a/client/discovery/i18n/ru.ts
+++ b/client/discovery/i18n/ru.ts
@@ -44,6 +44,15 @@ Object.assign(ru, { maintenance: { ...ru.maintenance,
     errors: { loadOverview: 'Не удалось загрузить обзор очистки', loadCandidates: 'Не удалось загрузить кандидатов', loadExclusions: 'Не удалось загрузить сводку исключений.', loadLibrary: 'Не удалось загрузить постеры библиотеки.', loadStorage: 'Не удалось загрузить сводку хранилища.' }
 } });
 
+Object.assign(ru, { settings: { ...ru.settings, logs: {
+    actions: { refresh: 'Обновить', refreshing: 'Обновление...', exportAll: 'Экспортировать всё', exporting: 'Экспорт…', unblock: 'Разблокировать' },
+    audit: { viewerTitle: 'Просмотр журнала аудита', empty: 'События аудита не найдены.', target: 'Цель', system: 'Система', actor: 'Исполнитель', field: 'Поле', before: 'До', after: 'После', value: 'Значение', unknownEvent: 'Событие' },
+    blocklist: { title: 'Список блокировки удалённых пользователей', empty: 'Сейчас нет заблокированных удалённых пользователей.', unknownUser: 'Неизвестный пользователь', noIdentifier: 'Нет идентификатора', deletedBy: 'Удалено {date} пользователем {actor}', defaultActor: 'администратор' },
+    email: { title: 'Журнал электронной почты', empty: 'Системные письма ещё не зарегистрированы.', systemEmail: 'Системное письмо', to: 'Кому' },
+    pagination: { previous: 'Назад', next: 'Далее', pageOf: 'Страница {page} из {total}' }, dialogs: { unblockUser: 'Разрешить {name} снова использовать портал? Приглашение не будет отправлено автоматически.' }, fallbacks: { thisUser: 'этот пользователь', notAvailable: 'Н/Д' },
+    errors: { loadAuditLog: 'Не удалось загрузить журнал аудита', exportAuditLog: 'Не удалось экспортировать журнал аудита', loadDeletedUsers: 'Не удалось загрузить журнал удалённых пользователей', unblockUser: 'Не удалось разблокировать пользователя.' }, toasts: { auditExported: 'Журнал аудита экспортирован (портал + Poster Sets + Upgrader).', userUnblocked: 'Удалённый пользователь разблокирован.' },
+} } });
+
 Object.assign(ru, { maintenance: {
     ...ru.maintenance,
     labels: { ...ru.maintenance.labels, true: 'Да', false: 'Нет', minMax: 'мин,макс', values: 'v1,v2', value: 'значение', enabled: 'Включено', disabled: 'Отключено', matches: 'Совпадения', grace: 'Льготный период', graceDays: 'Дни льготного периода', maxActions: 'Максимум действий', collectionName: 'Название коллекции', matchLogic: 'Логика совпадений', filterName: 'Имя фильтра', matchedTitles: 'Совпавшие названия', noPoster: 'Нет постера', eligible: 'Подходит', unmapped: 'Не сопоставлено', ambiguous: 'Неоднозначно', ...ru.maintenance?.labels, mapped: 'сопоставлено', instanceMappingHint: 'Неоднозначное сопоставление экземпляра', index: 'Индекс', mediaItems: 'медиаэлементов', lastBuild: 'Последняя сборка', requestRecords: 'Записи запросов',...ru.maintenance?.labels, matchLogicHint: 'Как объединяются условия правила.', graceHint: 'Общий льготный период для этого набора правил.', resetGraceHint: 'Сбросить льготный период этого правила сейчас.' },

--- a/client/settings/SettingsDashboard.tsx
+++ b/client/settings/SettingsDashboard.tsx
@@ -764,7 +764,7 @@ export const SettingsDashboard: React.FC = () => {
             setAuditLogPage(1);
             setEmailLogPage(1);
         } catch (e) {
-            addToast('Failed to load audit log', 'error');
+            addToast(t('settings.logs.errors.loadAuditLog'), 'error');
         } finally {
             setIsLoadingAuditLog(false);
         }
@@ -783,9 +783,9 @@ export const SettingsDashboard: React.FC = () => {
             anchor.click();
             anchor.remove();
             URL.revokeObjectURL(url);
-            addToast('Audit log exported (portal + Poster Sets + Upgrader).', 'success');
+            addToast(t('settings.logs.toasts.auditExported'), 'success');
         } catch (e) {
-            addToast(e instanceof Error ? e.message : 'Failed to export audit log', 'error');
+            addToast(e instanceof Error ? e.message : t('settings.logs.errors.exportAuditLog'), 'error');
         } finally {
             setIsExportingAuditLog(false);
         }
@@ -809,7 +809,7 @@ export const SettingsDashboard: React.FC = () => {
             const data = await apiFetch('/api/deleted-users');
             setDeletedUsersLog(Array.isArray(data) ? data : []);
         } catch (e) {
-            addToast('Failed to load deleted users log', 'error');
+            addToast(t('settings.logs.errors.loadDeletedUsers'), 'error');
         }
     };
 
@@ -967,15 +967,15 @@ export const SettingsDashboard: React.FC = () => {
     usePoll(() => { void fetchTasks(); }, tasksNeedLivePoll ? 2000 : null, { immediate: false });
 
     const handleUnblockDeletedUser = async (deletedUser: any) => {
-        const label = deletedUser.username || deletedUser.email || 'this user';
-        appConfirm(`Allow ${label} to use the portal again? This does not invite them automatically.`, async () => {
+        const label = deletedUser.username || deletedUser.email || t('settings.logs.fallbacks.thisUser');
+        appConfirm(t('settings.logs.dialogs.unblockUser', { name: label }), async () => {
             setLoading(true);
             try {
                 await apiFetch(`/api/deleted-users/${encodeURIComponent(deletedUser.blockId)}`, { method: 'DELETE' });
-                addToast('Deleted user unblocked.');
+                addToast(t('settings.logs.toasts.userUnblocked'));
                 await Promise.all([fetchDeletedUsersLog(), fetchAuditLog()]);
             } catch (error: any) {
-                addToast(error instanceof Error ? error.message : 'Failed to unblock user.', 'error');
+                addToast(error instanceof Error ? error.message : t('settings.logs.errors.unblockUser'), 'error');
             } finally {
                 setLoading(false);
             }
@@ -988,9 +988,9 @@ export const SettingsDashboard: React.FC = () => {
         .join(' ');
 
     const formatDateTime = (value?: string | null) => {
-        if (!value) return 'N/A';
+        if (!value) return t('settings.logs.fallbacks.notAvailable');
         const date = new Date(value);
-        if (Number.isNaN(date.getTime())) return 'N/A';
+        if (Number.isNaN(date.getTime())) return t('settings.logs.fallbacks.notAvailable');
         return date.toLocaleString();
     };
 
@@ -1027,12 +1027,12 @@ export const SettingsDashboard: React.FC = () => {
         };
 
         if ('before' in details && 'after' in details) {
-            rows.push({ field: 'Value', before: stringifyAuditValue(details.before), after: stringifyAuditValue(details.after) });
+            rows.push({ field: t('settings.logs.audit.value'), before: stringifyAuditValue(details.before), after: stringifyAuditValue(details.after) });
             used.add('before');
             used.add('after');
         }
         if ('oldValue' in details && 'newValue' in details) {
-            rows.push({ field: 'Value', before: stringifyAuditValue(details.oldValue), after: stringifyAuditValue(details.newValue) });
+            rows.push({ field: t('settings.logs.audit.value'), before: stringifyAuditValue(details.oldValue), after: stringifyAuditValue(details.newValue) });
             used.add('oldValue');
             used.add('newValue');
         }
@@ -4672,22 +4672,22 @@ export const SettingsDashboard: React.FC = () => {
 
                             <section className="space-y-4 mb-8">
                                 <div className="flex items-center justify-between">
-                                    <h4 className="font-bold text-text">Audit Log Viewer</h4>
+                                    <h4 className="font-bold text-text">{t('settings.logs.audit.viewerTitle')}</h4>
                                     <div className="flex items-center gap-2">
                                         <button
                                             className="px-3 py-1.5 bg-border text-text rounded-md font-semibold hover:bg-opacity-80 disabled:opacity-50"
                                             disabled={isExportingAuditLog}
                                             onClick={() => void exportAuditLog()}
                                         >
-                                            {isExportingAuditLog ? 'Exporting…' : 'Export all'}
+                                            {isExportingAuditLog ? t('settings.logs.actions.exporting') : t('settings.logs.actions.exportAll')}
                                         </button>
                                         <button className="px-3 py-1.5 bg-border text-text rounded-md font-semibold hover:bg-opacity-80" onClick={fetchAuditLog}>
-                                            {isLoadingAuditLog ? 'Refreshing...' : 'Refresh'}
+                                            {isLoadingAuditLog ? t('settings.logs.actions.refreshing') : t('settings.logs.actions.refresh')}
                                         </button>
                                     </div>
                                 </div>
                                 {pagedAuditEntries.length === 0 ? (
-                                    <p className="text-sm text-muted">No audit events found.</p>
+                                    <p className="text-sm text-muted">{t('settings.logs.audit.empty')}</p>
                                 ) : (
                                     <div className="space-y-3">
                                         {pagedAuditEntries.map((entry) => {
@@ -4699,12 +4699,12 @@ export const SettingsDashboard: React.FC = () => {
                                                 <details key={entry.id} className="py-3 border-b border-border/40 last:border-b-0">
                                                     <summary className="cursor-pointer list-none">
                                                         <div className="flex flex-wrap items-center justify-between gap-2">
-                                                            <p className="font-semibold text-text text-sm">{formatEventName(entry.event || 'event')}</p>
+                                                            <p className="font-semibold text-text text-sm">{entry.event ? formatEventName(entry.event) : t('settings.logs.audit.unknownEvent')}</p>
                                                             <span className="text-[11px] text-muted">{formatDateTime(entry.timestamp)}</span>
                                                         </div>
                                                         <p className="text-xs text-muted mt-1">
-                                                            Target: {entry.target?.username || entry.target?.email || 'System'}
-                                                            {entry.actor?.username || entry.actor?.email ? ` · Actor: ${entry.actor.username || entry.actor.email}` : ''}
+                                                            {t('settings.logs.audit.target')}: {entry.target?.username || entry.target?.email || t('settings.logs.audit.system')}
+                                                            {entry.actor?.username || entry.actor?.email ? ` · ${t('settings.logs.audit.actor')}: ${entry.actor.username || entry.actor.email}` : ''}
                                                         </p>
                                                     </summary>
                                                     <div className="mt-3 space-y-2">
@@ -4713,9 +4713,9 @@ export const SettingsDashboard: React.FC = () => {
                                                                 <table className="w-full text-xs border border-border/60 rounded-lg overflow-hidden">
                                                                     <thead className="bg-black/30 text-muted">
                                                                         <tr>
-                                                                            <th className="text-left px-2 py-1">Field</th>
-                                                                            <th className="text-left px-2 py-1">Before</th>
-                                                                            <th className="text-left px-2 py-1">After</th>
+                                                                            <th className="text-left px-2 py-1">{t('settings.logs.audit.field')}</th>
+                                                                            <th className="text-left px-2 py-1">{t('settings.logs.audit.before')}</th>
+                                                                            <th className="text-left px-2 py-1">{t('settings.logs.audit.after')}</th>
                                                                         </tr>
                                                                     </thead>
                                                                     <tbody>
@@ -4750,15 +4750,15 @@ export const SettingsDashboard: React.FC = () => {
                                                     disabled={auditLogPage === 1}
                                                     onClick={() => setAuditLogPage(p => Math.max(1, p - 1))}
                                                 >
-                                                    Previous
+                                                    {t('settings.logs.pagination.previous')}
                                                 </button>
-                                                <span className="text-xs text-muted">Page {auditLogPage} of {totalAuditLogPages}</span>
+                                                <span className="text-xs text-muted">{t('settings.logs.pagination.pageOf', { page: auditLogPage, total: totalAuditLogPages })}</span>
                                                 <button
                                                     className="px-3 py-1.5 bg-border text-text rounded-md font-semibold hover:bg-opacity-80 disabled:opacity-50"
                                                     disabled={auditLogPage === totalAuditLogPages}
                                                     onClick={() => setAuditLogPage(p => Math.min(totalAuditLogPages, p + 1))}
                                                 >
-                                                    Next
+                                                    {t('settings.logs.pagination.next')}
                                                 </button>
                                             </div>
                                         )}
@@ -4769,29 +4769,29 @@ export const SettingsDashboard: React.FC = () => {
                     )}
                     {activeTab === 'logs' && (
                         <div className="mb-8 animate-fade-in space-y-8">
-                            <h3 className="text-xl font-bold text-plex mb-4 border-b border-border pb-2">Logs & Audit</h3>
+                            <h3 className="text-xl font-bold text-plex mb-4 border-b border-border pb-2">{t('settings.navigation.tabs.logs')}</h3>
 
                             <section className="space-y-3">
                                 <div className="flex items-center justify-between">
-                                    <h4 className="font-bold text-text">Deleted User Blocklist</h4>
+                                    <h4 className="font-bold text-text">{t('settings.logs.blocklist.title')}</h4>
                                     <span className="px-2 py-1 rounded text-xs font-semibold bg-red-500/20 text-red-300">{deletedUsersLog.length}</span>
                                 </div>
                                 <div className="space-y-2">
                                     {deletedUsersLog.length === 0 ? (
-                                        <p className="text-sm text-muted">No deleted users are currently blocked.</p>
+                                        <p className="text-sm text-muted">{t('settings.logs.blocklist.empty')}</p>
                                     ) : (
                                         deletedUsersLog.map((deletedUser) => (
                                             <div key={deletedUser.blockId} className="py-3 border-b border-border/40 flex items-center justify-between gap-3 last:border-b-0">
                                                 <div className="min-w-0">
-                                                    <p className="text-sm font-semibold text-text truncate">{deletedUser.username || 'Unknown user'}</p>
-                                                    <p className="text-xs text-muted truncate">{deletedUser.email || deletedUser.plexId || deletedUser.id || 'No identifier'}</p>
-                                                    <p className="text-[11px] text-muted/80">Deleted {formatDateTime(deletedUser.deletedAt)} by {deletedUser.deletedBy || 'admin'}</p>
+                                                    <p className="text-sm font-semibold text-text truncate">{deletedUser.username || t('settings.logs.blocklist.unknownUser')}</p>
+                                                    <p className="text-xs text-muted truncate">{deletedUser.email || deletedUser.plexId || deletedUser.id || t('settings.logs.blocklist.noIdentifier')}</p>
+                                                    <p className="text-[11px] text-muted/80">{t('settings.logs.blocklist.deletedBy', { date: formatDateTime(deletedUser.deletedAt), actor: deletedUser.deletedBy || t('settings.logs.blocklist.defaultActor') })}</p>
                                                 </div>
                                                 <button
                                                     className="px-3 py-1.5 bg-border text-text rounded text-xs font-semibold hover:bg-opacity-80"
                                                     onClick={() => handleUnblockDeletedUser(deletedUser)}
                                                 >
-                                                    Unblock
+                                                    {t('settings.logs.actions.unblock')}
                                                 </button>
                                             </div>
                                         ))
@@ -4801,22 +4801,22 @@ export const SettingsDashboard: React.FC = () => {
 
                             <section className="space-y-3">
                                 <div className="flex items-center justify-between">
-                                    <h4 className="font-bold text-text">Email Log</h4>
+                                    <h4 className="font-bold text-text">{t('settings.logs.email.title')}</h4>
                                     <button className="px-3 py-1.5 bg-border text-text rounded-md font-semibold hover:bg-opacity-80" onClick={fetchAuditLog}>
-                                        {isLoadingAuditLog ? 'Refreshing...' : 'Refresh'}
+                                        {isLoadingAuditLog ? t('settings.logs.actions.refreshing') : t('settings.logs.actions.refresh')}
                                     </button>
                                 </div>
                                 {pagedEmailEntries.length === 0 ? (
-                                    <p className="text-sm text-muted">No system emails have been logged yet.</p>
+                                    <p className="text-sm text-muted">{t('settings.logs.email.empty')}</p>
                                 ) : (
                                     <div className="space-y-2">
                                         {pagedEmailEntries.map((entry) => (
                                             <div key={entry.id} className="py-3 border-b border-border/40 last:border-b-0">
                                                 <div className="flex items-start justify-between gap-3">
-                                                    <p className="text-sm font-semibold text-text line-clamp-1">{entry.details?.subject || 'System Email'}</p>
+                                                    <p className="text-sm font-semibold text-text line-clamp-1">{entry.details?.subject || t('settings.logs.email.systemEmail')}</p>
                                                     <span className="text-[11px] text-muted whitespace-nowrap">{formatDateTime(entry.timestamp)}</span>
                                                 </div>
-                                                <p className="text-xs text-muted mt-1">To: {entry.target?.username || entry.target?.email || 'Unknown user'}</p>
+                                                <p className="text-xs text-muted mt-1">{t('settings.logs.email.to')}: {entry.target?.username || entry.target?.email || t('settings.logs.blocklist.unknownUser')}</p>
                                             </div>
                                         ))}
                                         {totalEmailLogPages > 1 && (
@@ -4826,15 +4826,15 @@ export const SettingsDashboard: React.FC = () => {
                                                     disabled={emailLogPage === 1}
                                                     onClick={() => setEmailLogPage(p => Math.max(1, p - 1))}
                                                 >
-                                                    Previous
+                                                    {t('settings.logs.pagination.previous')}
                                                 </button>
-                                                <span className="text-xs text-muted">Page {emailLogPage} of {totalEmailLogPages}</span>
+                                                <span className="text-xs text-muted">{t('settings.logs.pagination.pageOf', { page: emailLogPage, total: totalEmailLogPages })}</span>
                                                 <button
                                                     className="px-3 py-1.5 bg-border text-text rounded-md font-semibold hover:bg-opacity-80 disabled:opacity-50"
                                                     disabled={emailLogPage === totalEmailLogPages}
                                                     onClick={() => setEmailLogPage(p => Math.min(totalEmailLogPages, p + 1))}
                                                 >
-                                                    Next
+                                                    {t('settings.logs.pagination.next')}
                                                 </button>
                                             </div>
                                         )}

--- a/docs/development/translation-status.md
+++ b/docs/development/translation-status.md
@@ -44,7 +44,7 @@ This table describes broad UI i18n wiring and known remaining work. It does not 
 | Requests admin UI | Partial |
 | Maintenance / Cleaner | i18n-enabled |
 | About | i18n-enabled |
-| Logs | Partial |
+| Logs | i18n-enabled |
 | Setup/admin utility areas | Mostly hardcoded |
 
 ## Current Recommended Small Batches


### PR DESCRIPTION
## Summary
- localize the reachable Settings Logs & Audit UI
- cover the active Audit Log Viewer, Deleted User Blocklist, and Email Log
- add a dedicated `settings.logs.*` namespace across all 10 supported locales
- preserve backend event IDs, raw audit payloads, dynamic data, and internal filter values

## Validation
- 37 effective `settings.logs.*` keys in every locale
- missing keys: 0
- extra keys: 0
- placeholder mismatches: 0
- `npm.cmd test` — 58 passed
- `npm.cmd run build:js` — passed
- `git diff --check` — passed

Existing unrelated Poster Sets duplicate-key warnings remain unchanged.

## Scope
This PR localizes only the currently reachable Logs & Audit surfaces inside Settings.

It includes:
- System tab Audit Log Viewer
- Logs tab Deleted User Blocklist
- Logs tab Email Log

It does not change:
- legacy `LogsDashboard`
- routing or hash behavior
- permissions
- API endpoints or query parameters
- pagination/filtering behavior
- export filenames/download behavior
- backend logging
- raw audit/log payload rendering

The translation status document is updated to mark Logs as i18n-enabled.