### PR TITLE
feat(i18n): localize Scanner dashboard

### DIFF
--- a/client/discovery/i18n/de.ts
+++ b/client/discovery/i18n/de.ts
@@ -458,6 +458,20 @@ Object.assign(de, { maintenance: { ...de.maintenance,
     calendar: { currentRule: 'Aktuelle Regel:', graceDays: 'Karenztage', ruleAge: 'Regelalter', eligibleNow: 'Jetzt berechtigt', laterReclaim: 'Spätere Rückgewinnung', daysUntilEligible: 'Tag(e) bis zur Berechtigung', titleCount: 'Titel', laterDetail: 'Diese Titel warten noch auf das Ende der Karenzzeit.', dateTitleCount: 'Anzahl der Titel für dieses Datum.', delayedReclaimTooltip: 'Schätzung der Rückgewinnung aus verzögerten Treffern.', eligibilityDetailTooltip: 'Berechtigungsdetails des Backends.', ago: 'Tage zuvor', notAvailable: 'n/v', ...de.maintenance.calendar }
 } });
 
+Object.assign(de, { scanner: {
+    dashboard: { eyebrow: 'Bibliotheksscanner', title: 'Präzise aktualisieren', description: 'Stelle einen Ordner für eine teilweise Bibliotheksaktualisierung auf Plex, Jellyfin oder Emby in die Warteschlange. ARR-Webhooks treffen hier automatisch als Importe, Upgrades, Löschungen und Umbenennungen ein.' },
+    manual: { title: 'Manueller Pfad', hiddenHint: 'Ausgeblendet — klicke, um einen Ordner manuell in die Warteschlange zu stellen.', visibleHint: 'Füge jetzt einen Ordner hinzu — er wird nach dem Mindestalter verarbeitet.', placeholder: 'Zu scannender Pfad, z. B. /mnt/unionfs/Media/Movies/Movie Name (year)', submitHint: 'Absenden fügt den Pfad zur Scan-Warteschlange hinzu', waitsBeforeTargets: ' · wartet ', beforeTargetsAreCalled: ', bevor die Ziele aufgerufen werden' },
+    actions: { refresh: 'Aktualisieren', submit: 'Absenden', copy: 'Kopieren' },
+    stats: { queued: 'In Warteschlange', queuedHint: 'Wartet auf Mindestalter', processed: 'Verarbeitet', processedHint: 'Erfolgreiche Aktualisierungen', targets: 'Ziele', targetsHint: 'Plex / JF / Emby', minAge: 'Mindestalter', minAgeHint: 'Verzögerung vor dem Scan' },
+    webhooks: { title: 'ARR-Webhooks', instructions: 'In Sonarr / Radarr / Lidarr: Einstellungen → Connect → Webhook → Bei Import + Bei Upgrade (und bei Löschen/Umbenennen, falls gewünscht). Verwende Basic Auth unter Einstellungen → Scanner.' },
+    queue: { title: 'Warteschlange', subtitle: 'Pfade, die auf das Mindestalter warten.', pending: '{count} ausstehend', empty: 'Die Warteschlange ist leer — warte auf den nächsten Webhook oder manuellen Pfad.' },
+    filters: { allConfiguredApps: 'Alle konfigurierten Apps', allEvents: 'Alle Ereignisse', imports: 'Importe', upgrades: 'Upgrades', deleted: 'Gelöscht', renames: 'Umbenennungen', manual: 'Manuell', refresh: 'Aktualisieren', other: 'Andere' },
+    activity: { title: 'Letzte Aktivitäten', subtitle: 'Letzte {total} Ereignisse · {perPage} pro Seite.', eventCount: '{count} Ereignisse', noScansProcessed: 'Noch keine Scans verarbeitet.', noEventsForSource: 'Keine {filter}-Ereignisse für {source}.', noEvents: 'Keine {filter}-Ereignisse.', noSourceActivity: 'Keine Aktivitäten für {source} gefunden.', ok: 'OK', error: 'Fehler', targetSkipped: '{target}: übersprungen', targetRefreshed: '{target}: aktualisiert', showing: '{from}–{to} von {total} angezeigt', actions: { import: 'Import', upgrade: 'Upgrade', fileDeleted: 'Datei gelöscht', seriesDeleted: 'Serie gelöscht', movieDeleted: 'Film gelöscht', artistDeleted: 'Künstler gelöscht', rename: 'Umbenennen', manual: 'Manuell', refresh: 'Aktualisieren', other: 'Andere' } },
+    pagination: { previous: 'Zurück', next: 'Weiter' },
+    errors: { load: 'Scanner konnte nicht geladen werden', queuePath: 'Pfad konnte nicht in die Warteschlange gestellt werden' },
+    toasts: { queued: 'In Warteschlange: {path}', copied: 'In die Zwischenablage kopiert' },
+} });
+
 Object.assign(de, { settings: { ...de.settings, logs: {
     actions: { refresh: 'Aktualisieren', refreshing: 'Aktualisierung...', exportAll: 'Alles exportieren', exporting: 'Export wird erstellt…', unblock: 'Entsperren' },
     audit: { viewerTitle: 'Auditprotokollanzeige', empty: 'Keine Audit-Ereignisse gefunden.', target: 'Ziel', system: 'System', actor: 'Akteur', field: 'Feld', before: 'Vorher', after: 'Nachher', value: 'Wert', unknownEvent: 'Ereignis' },

--- a/client/discovery/i18n/en.ts
+++ b/client/discovery/i18n/en.ts
@@ -1761,6 +1761,53 @@ export const en = {
         status: { open: 'Open', resolved: 'Resolved', closed: 'Closed' },
         categories: { media: 'Media request / problem', account: 'Account / access', server: 'Server / service', general: 'General question', other: 'Other' },
     },
+    scanner: {
+        dashboard: {
+            eyebrow: 'Library Scanner',
+            title: 'Refresh with precision',
+            description: 'Queue a folder for a partial library refresh on Plex, Jellyfin, or Emby. ARR webhooks land here automatically as imports, upgrades, deletes, and renames.',
+        },
+        manual: {
+            title: 'Manual path',
+            hiddenHint: 'Hidden — click to queue a folder manually.',
+            visibleHint: 'Add a folder now — processed after the minimum age.',
+            placeholder: 'Path to scan e.g. /mnt/unionfs/Media/Movies/Movie Name (year)',
+            submitHint: 'Submit adds the path to the scan queue',
+            waitsBeforeTargets: ' · waits ',
+            beforeTargetsAreCalled: ' before targets are called',
+        },
+        actions: { refresh: 'Refresh', submit: 'Submit', copy: 'Copy' },
+        stats: {
+            queued: 'Queued', queuedHint: 'Waiting for min age', processed: 'Processed', processedHint: 'Successful refreshes',
+            targets: 'Targets', targetsHint: 'Plex / JF / Emby', minAge: 'Min age', minAgeHint: 'Delay before scan',
+        },
+        webhooks: {
+            title: 'ARR webhooks',
+            instructions: 'In Sonarr / Radarr / Lidarr: Settings → Connect → Webhook → On Import + On Upgrade (and delete/rename if you want those too). Use Basic Auth from Settings → Scanner.',
+        },
+        queue: {
+            title: 'Queue', subtitle: 'Paths waiting for the minimum age.', pending: '{count} pending',
+            empty: 'Queue is empty — waiting for the next webhook or manual path.',
+        },
+        filters: {
+            allConfiguredApps: 'All configured apps', allEvents: 'All events', imports: 'Imports', upgrades: 'Upgrades',
+            deleted: 'Deleted', renames: 'Renames', manual: 'Manual', refresh: 'Refresh', other: 'Other',
+        },
+        activity: {
+            title: 'Recent activity', subtitle: 'Latest {total} events · {perPage} per page.', eventCount: '{count} events',
+            noScansProcessed: 'No scans processed yet.', noEventsForSource: 'No {filter} events for {source}.',
+            noEvents: 'No {filter} events.', noSourceActivity: 'No {source} activity found.', ok: 'OK', error: 'Error',
+            targetSkipped: '{target}: skipped', targetRefreshed: '{target}: refreshed', showing: 'Showing {from}–{to} of {total}',
+            actions: {
+                import: 'Import', upgrade: 'Upgrade', fileDeleted: 'File deleted', seriesDeleted: 'Series deleted',
+                movieDeleted: 'Movie deleted', artistDeleted: 'Artist deleted', rename: 'Rename', manual: 'Manual',
+                refresh: 'Refresh', other: 'Other',
+            },
+        },
+        pagination: { previous: 'Prev', next: 'Next' },
+        errors: { load: 'Failed to load scanner', queuePath: 'Failed to queue path' },
+        toasts: { queued: 'Queued: {path}', copied: 'Copied to clipboard' },
+    },
     maintenance: {
         rules: { title: 'Library Maintenance Rules', description: 'Saved filters are listed below. Click one to edit, preview, and run.', savedFilters: 'Saved Filters', noFilters: 'No filters yet. Click Add Filter.', unsaved: 'You have unsaved changes. Save the filter before previewing or running against production rules.', selectFilter: 'Select a saved filter to preview matches.' },
         actions: { rebuildIndex: 'Rebuild Index', addFilter: 'Add Filter', edit: 'Edit', refresh: 'Refresh', reset: 'Reset', delete: 'Delete', closeEditor: 'Close Editor', deleteFilter: 'Delete Filter', addCondition: 'Add Filter Condition', saveFilter: 'Save Filter', previewMatches: 'Preview Matches', runDry: 'Run Dry-Run', runDestructive: 'Run Destructive' },

--- a/client/discovery/i18n/es.ts
+++ b/client/discovery/i18n/es.ts
@@ -462,6 +462,20 @@ Object.assign(es, { maintenance: { ...es.maintenance,
     errors: { loadOverview: 'No se pudo cargar el resumen de limpieza', loadCandidates: 'No se pudieron cargar los candidatos', loadExclusions: 'No se pudo cargar el resumen de exclusiones.', loadLibrary: 'No se pudieron cargar los pósteres de la biblioteca.', loadStorage: 'No se pudo cargar el resumen de almacenamiento.' }
 } });
 
+Object.assign(es, { scanner: {
+    dashboard: { eyebrow: 'Escáner de biblioteca', title: 'Actualiza con precisión', description: 'Pon una carpeta en cola para actualizar parcialmente una biblioteca en Plex, Jellyfin o Emby. Los webhooks de ARR llegan aquí automáticamente como importaciones, mejoras, eliminaciones y cambios de nombre.' },
+    manual: { title: 'Ruta manual', hiddenHint: 'Oculto — haz clic para poner una carpeta en cola manualmente.', visibleHint: 'Añade una carpeta ahora — se procesará después de la antigüedad mínima.', placeholder: 'Ruta que analizar, p. ej. /mnt/unionfs/Media/Movies/Movie Name (year)', submitHint: 'Enviar añade la ruta a la cola de análisis', waitsBeforeTargets: ' · espera ', beforeTargetsAreCalled: ' antes de llamar a los destinos' },
+    actions: { refresh: 'Actualizar', submit: 'Enviar', copy: 'Copiar' },
+    stats: { queued: 'En cola', queuedHint: 'Esperando la antigüedad mínima', processed: 'Procesados', processedHint: 'Actualizaciones correctas', targets: 'Destinos', targetsHint: 'Plex / JF / Emby', minAge: 'Antigüedad mínima', minAgeHint: 'Retraso antes del análisis' },
+    webhooks: { title: 'Webhooks de ARR', instructions: 'En Sonarr / Radarr / Lidarr: Ajustes → Connect → Webhook → Al importar + Al actualizar (y eliminar/cambiar nombre si también los quieres). Usa la autenticación básica desde Ajustes → Scanner.' },
+    queue: { title: 'Cola', subtitle: 'Rutas esperando la antigüedad mínima.', pending: '{count} pendientes', empty: 'La cola está vacía — esperando el próximo webhook o ruta manual.' },
+    filters: { allConfiguredApps: 'Todas las aplicaciones configuradas', allEvents: 'Todos los eventos', imports: 'Importaciones', upgrades: 'Mejoras', deleted: 'Eliminados', renames: 'Cambios de nombre', manual: 'Manual', refresh: 'Actualizar', other: 'Otro' },
+    activity: { title: 'Actividad reciente', subtitle: 'Últimos {total} eventos · {perPage} por página.', eventCount: '{count} eventos', noScansProcessed: 'Aún no se ha procesado ningún análisis.', noEventsForSource: 'No hay eventos de {filter} para {source}.', noEvents: 'No hay eventos de {filter}.', noSourceActivity: 'No se encontró actividad de {source}.', ok: 'Correcto', error: 'Error', targetSkipped: '{target}: omitido', targetRefreshed: '{target}: actualizado', showing: 'Mostrando {from}–{to} de {total}', actions: { import: 'Importación', upgrade: 'Mejora', fileDeleted: 'Archivo eliminado', seriesDeleted: 'Serie eliminada', movieDeleted: 'Película eliminada', artistDeleted: 'Artista eliminado', rename: 'Cambiar nombre', manual: 'Manual', refresh: 'Actualizar', other: 'Otro' } },
+    pagination: { previous: 'Anterior', next: 'Siguiente' },
+    errors: { load: 'No se pudo cargar Scanner', queuePath: 'No se pudo poner la ruta en cola' },
+    toasts: { queued: 'En cola: {path}', copied: 'Copiado al portapapeles' },
+} });
+
 Object.assign(es, { settings: { ...es.settings, logs: {
     actions: { refresh: 'Actualizar', refreshing: 'Actualizando...', exportAll: 'Exportar todo', exporting: 'Exportando…', unblock: 'Desbloquear' },
     audit: { viewerTitle: 'Visor del registro de auditoría', empty: 'No se encontraron eventos de auditoría.', target: 'Destino', system: 'Sistema', actor: 'Autor', field: 'Campo', before: 'Antes', after: 'Después', value: 'Valor', unknownEvent: 'Evento' },

--- a/client/discovery/i18n/fr.ts
+++ b/client/discovery/i18n/fr.ts
@@ -1775,6 +1775,20 @@ Object.assign(fr, { maintenance: {
             errors: { ...fr.maintenance.errors, loadOverview: 'Impossible de charger la vue d’ensemble du nettoyage', loadCandidates: 'Impossible de charger les candidats', loadExclusions: 'Impossible de charger le résumé des exclusions.', loadLibrary: 'Impossible de charger les affiches de la bibliothèque.', loadStorage: 'Impossible de charger le résumé du stockage.' }
 } });
 
+Object.assign(fr, { scanner: {
+    dashboard: { eyebrow: 'Scanner de bibliothèque', title: 'Rafraîchir avec précision', description: 'Mettez un dossier en file d’attente pour rafraîchir partiellement une bibliothèque Plex, Jellyfin ou Emby. Les webhooks ARR arrivent ici automatiquement lors des importations, mises à niveau, suppressions et renommages.' },
+    manual: { title: 'Chemin manuel', hiddenHint: 'Masqué — cliquez pour mettre un dossier en file d’attente manuellement.', visibleHint: 'Ajoutez un dossier maintenant — il sera traité après l’âge minimal.', placeholder: 'Chemin à analyser, par ex. /mnt/unionfs/Media/Movies/Movie Name (year)', submitHint: 'Envoyer ajoute le chemin à la file d’attente d’analyse', waitsBeforeTargets: ' · attend ', beforeTargetsAreCalled: ' avant de lancer les cibles' },
+    actions: { refresh: 'Actualiser', submit: 'Envoyer', copy: 'Copier' },
+    stats: { queued: 'En attente', queuedHint: 'En attente de l’âge minimal', processed: 'Traités', processedHint: 'Rafraîchissements réussis', targets: 'Cibles', targetsHint: 'Plex / JF / Emby', minAge: 'Âge minimal', minAgeHint: 'Délai avant l’analyse' },
+    webhooks: { title: 'Webhooks ARR', instructions: 'Dans Sonarr / Radarr / Lidarr : Paramètres → Connecter → Webhook → À l’importation + À la mise à niveau (et suppression/renommage si nécessaire). Utilisez l’authentification basique depuis Paramètres → Scanner.' },
+    queue: { title: 'File d’attente', subtitle: 'Chemins en attente de l’âge minimal.', pending: '{count} en attente', empty: 'La file d’attente est vide — en attente du prochain webhook ou chemin manuel.' },
+    filters: { allConfiguredApps: 'Toutes les applications configurées', allEvents: 'Tous les événements', imports: 'Importations', upgrades: 'Mises à niveau', deleted: 'Supprimés', renames: 'Renommages', manual: 'Manuel', refresh: 'Actualiser', other: 'Autre' },
+    activity: { title: 'Activité récente', subtitle: '{total} derniers événements · {perPage} par page.', eventCount: '{count} événements', noScansProcessed: 'Aucune analyse traitée pour le moment.', noEventsForSource: 'Aucun événement {filter} pour {source}.', noEvents: 'Aucun événement {filter}.', noSourceActivity: 'Aucune activité {source} trouvée.', ok: 'OK', error: 'Erreur', targetSkipped: '{target} : ignoré', targetRefreshed: '{target} : rafraîchi', showing: 'Affichage de {from}–{to} sur {total}', actions: { import: 'Importation', upgrade: 'Mise à niveau', fileDeleted: 'Fichier supprimé', seriesDeleted: 'Série supprimée', movieDeleted: 'Film supprimé', artistDeleted: 'Artiste supprimé', rename: 'Renommage', manual: 'Manuel', refresh: 'Actualisation', other: 'Autre' } },
+    pagination: { previous: 'Préc.', next: 'Suiv.' },
+    errors: { load: 'Impossible de charger le Scanner', queuePath: 'Impossible de mettre le chemin en file d’attente' },
+    toasts: { queued: 'Mis en file d’attente : {path}', copied: 'Copié dans le presse-papiers' },
+} });
+
 Object.assign(fr, { settings: { ...fr.settings, logs: {
     actions: { refresh: 'Actualiser', refreshing: 'Actualisation...', exportAll: 'Tout exporter', exporting: 'Exportation…', unblock: 'Débloquer' },
     audit: { viewerTitle: 'Visionneuse du journal d’audit', empty: 'Aucun événement d’audit trouvé.', target: 'Cible', system: 'Système', actor: 'Auteur', field: 'Champ', before: 'Avant', after: 'Après', value: 'Valeur', unknownEvent: 'Événement' },

--- a/client/discovery/i18n/it.ts
+++ b/client/discovery/i18n/it.ts
@@ -44,6 +44,20 @@ Object.assign(it, { maintenance: { ...it.maintenance,
     errors: { loadOverview: 'Impossibile caricare il riepilogo della pulizia', loadCandidates: 'Impossibile caricare i candidati', loadExclusions: 'Impossibile caricare il riepilogo delle esclusioni.', loadLibrary: 'Impossibile caricare i poster della libreria.', loadStorage: 'Impossibile caricare il riepilogo dello spazio.' }
 } });
 
+Object.assign(it, { scanner: {
+    dashboard: { eyebrow: 'Scanner della libreria', title: 'Aggiorna con precisione', description: 'Metti una cartella in coda per un aggiornamento parziale della libreria su Plex, Jellyfin o Emby. I webhook ARR arrivano qui automaticamente come importazioni, aggiornamenti, eliminazioni e rinominazioni.' },
+    manual: { title: 'Percorso manuale', hiddenHint: 'Nascosto — fai clic per mettere manualmente una cartella in coda.', visibleHint: 'Aggiungi ora una cartella — verrà elaborata dopo l’età minima.', placeholder: 'Percorso da analizzare, ad es. /mnt/unionfs/Media/Movies/Movie Name (year)', submitHint: 'Invia aggiunge il percorso alla coda di scansione', waitsBeforeTargets: ' · attende ', beforeTargetsAreCalled: ' prima di chiamare le destinazioni' },
+    actions: { refresh: 'Aggiorna', submit: 'Invia', copy: 'Copia' },
+    stats: { queued: 'In coda', queuedHint: 'In attesa dell’età minima', processed: 'Elaborati', processedHint: 'Aggiornamenti riusciti', targets: 'Destinazioni', targetsHint: 'Plex / JF / Emby', minAge: 'Età minima', minAgeHint: 'Ritardo prima della scansione' },
+    webhooks: { title: 'Webhook ARR', instructions: 'In Sonarr / Radarr / Lidarr: Impostazioni → Connect → Webhook → All’importazione + All’aggiornamento (e all’eliminazione/rinominazione se li vuoi anche per questi eventi). Usa l’autenticazione di base da Impostazioni → Scanner.' },
+    queue: { title: 'Coda', subtitle: 'Percorsi in attesa dell’età minima.', pending: '{count} in attesa', empty: 'La coda è vuota — in attesa del prossimo webhook o percorso manuale.' },
+    filters: { allConfiguredApps: 'Tutte le app configurate', allEvents: 'Tutti gli eventi', imports: 'Importazioni', upgrades: 'Aggiornamenti', deleted: 'Eliminati', renames: 'Rinominazioni', manual: 'Manuale', refresh: 'Aggiorna', other: 'Altro' },
+    activity: { title: 'Attività recente', subtitle: 'Ultimi {total} eventi · {perPage} per pagina.', eventCount: '{count} eventi', noScansProcessed: 'Nessuna scansione elaborata finora.', noEventsForSource: 'Nessun evento {filter} per {source}.', noEvents: 'Nessun evento {filter}.', noSourceActivity: 'Nessuna attività {source} trovata.', ok: 'OK', error: 'Errore', targetSkipped: '{target}: ignorato', targetRefreshed: '{target}: aggiornato', showing: 'Visualizzazione di {from}–{to} su {total}', actions: { import: 'Importazione', upgrade: 'Aggiornamento', fileDeleted: 'File eliminato', seriesDeleted: 'Serie eliminata', movieDeleted: 'Film eliminato', artistDeleted: 'Artista eliminato', rename: 'Rinomina', manual: 'Manuale', refresh: 'Aggiorna', other: 'Altro' } },
+    pagination: { previous: 'Precedente', next: 'Successivo' },
+    errors: { load: 'Impossibile caricare Scanner', queuePath: 'Impossibile mettere il percorso in coda' },
+    toasts: { queued: 'In coda: {path}', copied: 'Copiato negli appunti' },
+} });
+
 Object.assign(it, { settings: { ...it.settings, logs: {
     actions: { refresh: 'Aggiorna', refreshing: 'Aggiornamento...', exportAll: 'Esporta tutto', exporting: 'Esportazione…', unblock: 'Sblocca' },
     audit: { viewerTitle: 'Visualizzatore del registro di controllo', empty: 'Nessun evento di controllo trovato.', target: 'Destinazione', system: 'Sistema', actor: 'Autore', field: 'Campo', before: 'Prima', after: 'Dopo', value: 'Valore', unknownEvent: 'Evento' },

--- a/client/discovery/i18n/ja.ts
+++ b/client/discovery/i18n/ja.ts
@@ -44,6 +44,20 @@ Object.assign(ja, { maintenance: { ...ja.maintenance,
     errors: { loadOverview: 'クリーナー概要を読み込めませんでした', loadCandidates: '候補を読み込めませんでした', loadExclusions: '除外の概要を読み込めませんでした。', loadLibrary: 'ライブラリのポスターを読み込めませんでした。', loadStorage: 'ストレージ概要を読み込めませんでした。' }
 } });
 
+Object.assign(ja, { scanner: {
+    dashboard: { eyebrow: 'ライブラリスキャナー', title: '正確に更新', description: 'Plex、Jellyfin、Emby のライブラリを部分更新するためにフォルダーをキューへ追加します。ARR の Webhook は、インポート、アップグレード、削除、名前変更として自動的にここへ届きます。' },
+    manual: { title: '手動パス', hiddenHint: '非表示です — クリックしてフォルダーを手動でキューに追加します。', visibleHint: '今すぐフォルダーを追加できます — 最低経過時間後に処理されます。', placeholder: 'スキャンするパス（例: /mnt/unionfs/Media/Movies/Movie Name (year)）', submitHint: '送信するとパスがスキャンキューに追加されます', waitsBeforeTargets: ' · ', beforeTargetsAreCalled: '待機してからターゲットを呼び出します' },
+    actions: { refresh: '更新', submit: '送信', copy: 'コピー' },
+    stats: { queued: 'キュー済み', queuedHint: '最低経過時間を待機中', processed: '処理済み', processedHint: '更新成功数', targets: 'ターゲット', targetsHint: 'Plex / JF / Emby', minAge: '最低経過時間', minAgeHint: 'スキャン前の待機時間' },
+    webhooks: { title: 'ARR Webhook', instructions: 'Sonarr / Radarr / Lidarr で: Settings → Connect → Webhook → On Import + On Upgrade（削除/名前変更も必要なら有効化）。Settings → Scanner の Basic Auth を使用します。' },
+    queue: { title: 'キュー', subtitle: '最低経過時間を待っているパス。', pending: '{count} 件保留中', empty: 'キューは空です — 次の Webhook または手動パスを待っています。' },
+    filters: { allConfiguredApps: '設定済みのすべてのアプリ', allEvents: 'すべてのイベント', imports: 'インポート', upgrades: 'アップグレード', deleted: '削除済み', renames: '名前変更', manual: '手動', refresh: '更新', other: 'その他' },
+    activity: { title: '最近のアクティビティ', subtitle: '最新 {total} 件のイベント · 1 ページあたり {perPage} 件。', eventCount: '{count} 件のイベント', noScansProcessed: 'まだ処理されたスキャンはありません。', noEventsForSource: '{source} の {filter} イベントはありません。', noEvents: '{filter} イベントはありません。', noSourceActivity: '{source} のアクティビティは見つかりませんでした。', ok: 'OK', error: 'エラー', targetSkipped: '{target}: スキップ', targetRefreshed: '{target}: 更新済み', showing: '{total} 件中 {from}～{to} 件を表示', actions: { import: 'インポート', upgrade: 'アップグレード', fileDeleted: 'ファイルを削除', seriesDeleted: 'シリーズを削除', movieDeleted: '映画を削除', artistDeleted: 'アーティストを削除', rename: '名前変更', manual: '手動', refresh: '更新', other: 'その他' } },
+    pagination: { previous: '前へ', next: '次へ' },
+    errors: { load: 'Scanner を読み込めませんでした', queuePath: 'パスをキューに追加できませんでした' },
+    toasts: { queued: 'キューに追加しました: {path}', copied: 'クリップボードにコピーしました' },
+} });
+
 Object.assign(ja, { settings: { ...ja.settings, logs: {
     actions: { refresh: '更新', refreshing: '更新中...', exportAll: 'すべてエクスポート', exporting: 'エクスポート中…', unblock: 'ブロック解除' },
     audit: { viewerTitle: '監査ログビューアー', empty: '監査イベントが見つかりません。', target: '対象', system: 'システム', actor: '実行者', field: '項目', before: '変更前', after: '変更後', value: '値', unknownEvent: 'イベント' },

--- a/client/discovery/i18n/nl.ts
+++ b/client/discovery/i18n/nl.ts
@@ -44,6 +44,20 @@ Object.assign(nl, { maintenance: { ...nl.maintenance,
     errors: { loadOverview: 'Overzicht van opschonen kon niet worden geladen', loadCandidates: 'Kandidaten konden niet worden geladen', loadExclusions: 'Samenvatting van uitsluitingen kon niet worden geladen.', loadLibrary: 'Bibliotheekposters konden niet worden geladen.', loadStorage: 'Opslagsamenvatting kon niet worden geladen.' }
 } });
 
+Object.assign(nl, { scanner: {
+    dashboard: { eyebrow: 'Bibliotheekscanner', title: 'Nauwkeurig vernieuwen', description: 'Zet een map in de wachtrij voor een gedeeltelijke bibliotheekvernieuwing op Plex, Jellyfin of Emby. ARR-webhooks komen hier automatisch binnen als importen, upgrades, verwijderingen en naamswijzigingen.' },
+    manual: { title: 'Handmatig pad', hiddenHint: 'Verborgen — klik om handmatig een map in de wachtrij te zetten.', visibleHint: 'Voeg nu een map toe — deze wordt verwerkt na de minimale wachttijd.', placeholder: 'Te scannen pad, bijv. /mnt/unionfs/Media/Movies/Movie Name (year)', submitHint: 'Verzenden voegt het pad toe aan de scanwachtrij', waitsBeforeTargets: ' · wacht ', beforeTargetsAreCalled: ' voordat de doelen worden aangeroepen' },
+    actions: { refresh: 'Vernieuwen', submit: 'Verzenden', copy: 'Kopiëren' },
+    stats: { queued: 'In wachtrij', queuedHint: 'Wacht op minimale wachttijd', processed: 'Verwerkt', processedHint: 'Geslaagde vernieuwingen', targets: 'Doelen', targetsHint: 'Plex / JF / Emby', minAge: 'Minimale wachttijd', minAgeHint: 'Vertraging voor de scan' },
+    webhooks: { title: 'ARR-webhooks', instructions: 'In Sonarr / Radarr / Lidarr: Instellingen → Connect → Webhook → On Import + On Upgrade (en verwijderen/naam wijzigen als je die ook wilt). Gebruik Basic Auth vanuit Instellingen → Scanner.' },
+    queue: { title: 'Wachtrij', subtitle: 'Paden die wachten op de minimale wachttijd.', pending: '{count} in behandeling', empty: 'De wachtrij is leeg — wacht op de volgende webhook of het volgende handmatige pad.' },
+    filters: { allConfiguredApps: 'Alle geconfigureerde apps', allEvents: 'Alle gebeurtenissen', imports: 'Importen', upgrades: 'Upgrades', deleted: 'Verwijderd', renames: 'Naamswijzigingen', manual: 'Handmatig', refresh: 'Vernieuwen', other: 'Overig' },
+    activity: { title: 'Recente activiteit', subtitle: 'Laatste {total} gebeurtenissen · {perPage} per pagina.', eventCount: '{count} gebeurtenissen', noScansProcessed: 'Nog geen scans verwerkt.', noEventsForSource: 'Geen {filter}-gebeurtenissen voor {source}.', noEvents: 'Geen {filter}-gebeurtenissen.', noSourceActivity: 'Geen activiteit voor {source} gevonden.', ok: 'OK', error: 'Fout', targetSkipped: '{target}: overgeslagen', targetRefreshed: '{target}: vernieuwd', showing: '{from}–{to} van {total} weergegeven', actions: { import: 'Importeren', upgrade: 'Upgrade', fileDeleted: 'Bestand verwijderd', seriesDeleted: 'Serie verwijderd', movieDeleted: 'Film verwijderd', artistDeleted: 'Artiest verwijderd', rename: 'Hernoemen', manual: 'Handmatig', refresh: 'Vernieuwen', other: 'Overig' } },
+    pagination: { previous: 'Vorige', next: 'Volgende' },
+    errors: { load: 'Scanner kon niet worden geladen', queuePath: 'Pad kon niet in de wachtrij worden gezet' },
+    toasts: { queued: 'In wachtrij gezet: {path}', copied: 'Gekopieerd naar het klembord' },
+} });
+
 Object.assign(nl, { settings: { ...nl.settings, logs: {
     actions: { refresh: 'Vernieuwen', refreshing: 'Vernieuwen...', exportAll: 'Alles exporteren', exporting: 'Exporteren…', unblock: 'Deblokkeren' },
     audit: { viewerTitle: 'Auditlogviewer', empty: 'Geen auditgebeurtenissen gevonden.', target: 'Doel', system: 'Systeem', actor: 'Uitvoerder', field: 'Veld', before: 'Vóór', after: 'Na', value: 'Waarde', unknownEvent: 'Gebeurtenis' },

--- a/client/discovery/i18n/pl.ts
+++ b/client/discovery/i18n/pl.ts
@@ -44,6 +44,20 @@ Object.assign(pl, { maintenance: { ...pl.maintenance,
     errors: { loadOverview: 'Nie udało się wczytać przeglądu czyszczenia', loadCandidates: 'Nie udało się wczytać kandydatów', loadExclusions: 'Nie udało się wczytać podsumowania wykluczeń.', loadLibrary: 'Nie udało się wczytać plakatów biblioteki.', loadStorage: 'Nie udało się wczytać podsumowania pamięci.' }
 } });
 
+Object.assign(pl, { scanner: {
+    dashboard: { eyebrow: 'Skaner biblioteki', title: 'Odświeżaj precyzyjnie', description: 'Dodaj folder do kolejki, aby częściowo odświeżyć bibliotekę Plex, Jellyfin lub Emby. Webhooki ARR trafiają tutaj automatycznie jako importy, aktualizacje, usunięcia i zmiany nazw.' },
+    manual: { title: 'Ścieżka ręczna', hiddenHint: 'Ukryte — kliknij, aby ręcznie dodać folder do kolejki.', visibleHint: 'Dodaj folder teraz — zostanie przetworzony po minimalnym czasie oczekiwania.', placeholder: 'Ścieżka do skanowania, np. /mnt/unionfs/Media/Movies/Movie Name (year)', submitHint: 'Wyślij dodaje ścieżkę do kolejki skanowania', waitsBeforeTargets: ' · czeka ', beforeTargetsAreCalled: ' przed wywołaniem celów' },
+    actions: { refresh: 'Odśwież', submit: 'Wyślij', copy: 'Kopiuj' },
+    stats: { queued: 'W kolejce', queuedHint: 'Oczekiwanie na minimalny czas', processed: 'Przetworzone', processedHint: 'Udane odświeżenia', targets: 'Cele', targetsHint: 'Plex / JF / Emby', minAge: 'Minimalny czas', minAgeHint: 'Opóźnienie przed skanowaniem' },
+    webhooks: { title: 'Webhooki ARR', instructions: 'W Sonarr / Radarr / Lidarr: Ustawienia → Connect → Webhook → On Import + On Upgrade (oraz usuwanie/zmiana nazwy, jeśli też ich potrzebujesz). Użyj Basic Auth z Ustawienia → Scanner.' },
+    queue: { title: 'Kolejka', subtitle: 'Ścieżki oczekujące na minimalny czas.', pending: 'Oczekujących: {count}', empty: 'Kolejka jest pusta — oczekiwanie na następny webhook lub ścieżkę ręczną.' },
+    filters: { allConfiguredApps: 'Wszystkie skonfigurowane aplikacje', allEvents: 'Wszystkie zdarzenia', imports: 'Importy', upgrades: 'Aktualizacje', deleted: 'Usunięte', renames: 'Zmiany nazw', manual: 'Ręcznie', refresh: 'Odśwież', other: 'Inne' },
+    activity: { title: 'Ostatnia aktywność', subtitle: 'Ostatnie {total} zdarzeń · {perPage} na stronę.', eventCount: 'Liczba zdarzeń: {count}', noScansProcessed: 'Nie przetworzono jeszcze żadnego skanowania.', noEventsForSource: 'Brak zdarzeń {filter} dla {source}.', noEvents: 'Brak zdarzeń {filter}.', noSourceActivity: 'Nie znaleziono aktywności dla {source}.', ok: 'OK', error: 'Błąd', targetSkipped: '{target}: pominięto', targetRefreshed: '{target}: odświeżono', showing: 'Wyświetlanie {from}–{to} z {total}', actions: { import: 'Import', upgrade: 'Aktualizacja', fileDeleted: 'Plik usunięty', seriesDeleted: 'Serial usunięty', movieDeleted: 'Film usunięty', artistDeleted: 'Artysta usunięty', rename: 'Zmień nazwę', manual: 'Ręcznie', refresh: 'Odśwież', other: 'Inne' } },
+    pagination: { previous: 'Poprzednia', next: 'Następna' },
+    errors: { load: 'Nie udało się wczytać Scanner', queuePath: 'Nie udało się dodać ścieżki do kolejki' },
+    toasts: { queued: 'Dodano do kolejki: {path}', copied: 'Skopiowano do schowka' },
+} });
+
 Object.assign(pl, { settings: { ...pl.settings, logs: {
     actions: { refresh: 'Odśwież', refreshing: 'Odświeżanie...', exportAll: 'Eksportuj wszystko', exporting: 'Eksportowanie…', unblock: 'Odblokuj' },
     audit: { viewerTitle: 'Przeglądarka dziennika audytu', empty: 'Nie znaleziono zdarzeń audytu.', target: 'Cel', system: 'System', actor: 'Wykonawca', field: 'Pole', before: 'Przed', after: 'Po', value: 'Wartość', unknownEvent: 'Zdarzenie' },

--- a/client/discovery/i18n/pt-BR.ts
+++ b/client/discovery/i18n/pt-BR.ts
@@ -44,6 +44,20 @@ Object.assign(ptBR, { maintenance: { ...ptBR.maintenance,
     errors: { loadOverview: 'Não foi possível carregar o resumo da limpeza', loadCandidates: 'Não foi possível carregar os candidatos', loadExclusions: 'Não foi possível carregar o resumo das exclusões.', loadLibrary: 'Não foi possível carregar os pôsteres da biblioteca.', loadStorage: 'Não foi possível carregar o resumo do armazenamento.' }
 } });
 
+Object.assign(ptBR, { scanner: {
+    dashboard: { eyebrow: 'Scanner de biblioteca', title: 'Atualize com precisão', description: 'Coloque uma pasta na fila para uma atualização parcial da biblioteca no Plex, Jellyfin ou Emby. Os webhooks do ARR chegam aqui automaticamente como importações, atualizações, exclusões e renomeações.' },
+    manual: { title: 'Caminho manual', hiddenHint: 'Oculto — clique para colocar uma pasta na fila manualmente.', visibleHint: 'Adicione uma pasta agora — ela será processada após a idade mínima.', placeholder: 'Caminho para verificar, ex. /mnt/unionfs/Media/Movies/Movie Name (year)', submitHint: 'Enviar adiciona o caminho à fila de varredura', waitsBeforeTargets: ' · aguarda ', beforeTargetsAreCalled: ' antes de chamar os destinos' },
+    actions: { refresh: 'Atualizar', submit: 'Enviar', copy: 'Copiar' },
+    stats: { queued: 'Na fila', queuedHint: 'Aguardando a idade mínima', processed: 'Processados', processedHint: 'Atualizações bem-sucedidas', targets: 'Destinos', targetsHint: 'Plex / JF / Emby', minAge: 'Idade mínima', minAgeHint: 'Atraso antes da verificação' },
+    webhooks: { title: 'Webhooks do ARR', instructions: 'No Sonarr / Radarr / Lidarr: Configurações → Connect → Webhook → Ao importar + Ao atualizar (e excluir/renomear, se também quiser esses eventos). Use a autenticação básica em Configurações → Scanner.' },
+    queue: { title: 'Fila', subtitle: 'Caminhos aguardando a idade mínima.', pending: '{count} pendentes', empty: 'A fila está vazia — aguardando o próximo webhook ou caminho manual.' },
+    filters: { allConfiguredApps: 'Todos os aplicativos configurados', allEvents: 'Todos os eventos', imports: 'Importações', upgrades: 'Atualizações', deleted: 'Excluídos', renames: 'Renomeações', manual: 'Manual', refresh: 'Atualizar', other: 'Outro' },
+    activity: { title: 'Atividade recente', subtitle: 'Últimos {total} eventos · {perPage} por página.', eventCount: '{count} eventos', noScansProcessed: 'Nenhuma verificação processada ainda.', noEventsForSource: 'Nenhum evento de {filter} para {source}.', noEvents: 'Nenhum evento de {filter}.', noSourceActivity: 'Nenhuma atividade de {source} encontrada.', ok: 'OK', error: 'Erro', targetSkipped: '{target}: ignorado', targetRefreshed: '{target}: atualizado', showing: 'Mostrando {from}–{to} de {total}', actions: { import: 'Importação', upgrade: 'Atualização', fileDeleted: 'Arquivo excluído', seriesDeleted: 'Série excluída', movieDeleted: 'Filme excluído', artistDeleted: 'Artista excluído', rename: 'Renomear', manual: 'Manual', refresh: 'Atualizar', other: 'Outro' } },
+    pagination: { previous: 'Anterior', next: 'Próxima' },
+    errors: { load: 'Não foi possível carregar o Scanner', queuePath: 'Não foi possível colocar o caminho na fila' },
+    toasts: { queued: 'Na fila: {path}', copied: 'Copiado para a área de transferência' },
+} });
+
 Object.assign(ptBR, { settings: { ...ptBR.settings, logs: {
     actions: { refresh: 'Atualizar', refreshing: 'Atualizando...', exportAll: 'Exportar tudo', exporting: 'Exportando…', unblock: 'Desbloquear' },
     audit: { viewerTitle: 'Visualizador do registro de auditoria', empty: 'Nenhum evento de auditoria encontrado.', target: 'Destino', system: 'Sistema', actor: 'Autor', field: 'Campo', before: 'Antes', after: 'Depois', value: 'Valor', unknownEvent: 'Evento' },

--- a/client/discovery/i18n/ru.ts
+++ b/client/discovery/i18n/ru.ts
@@ -44,6 +44,20 @@ Object.assign(ru, { maintenance: { ...ru.maintenance,
     errors: { loadOverview: 'Не удалось загрузить обзор очистки', loadCandidates: 'Не удалось загрузить кандидатов', loadExclusions: 'Не удалось загрузить сводку исключений.', loadLibrary: 'Не удалось загрузить постеры библиотеки.', loadStorage: 'Не удалось загрузить сводку хранилища.' }
 } });
 
+Object.assign(ru, { scanner: {
+    dashboard: { eyebrow: 'Сканер библиотеки', title: 'Точное обновление', description: 'Добавьте папку в очередь для частичного обновления библиотеки Plex, Jellyfin или Emby. Webhook-и ARR автоматически поступают сюда как импорты, обновления, удаления и переименования.' },
+    manual: { title: 'Ручной путь', hiddenHint: 'Скрыто — нажмите, чтобы вручную добавить папку в очередь.', visibleHint: 'Добавьте папку сейчас — она будет обработана после минимального времени ожидания.', placeholder: 'Путь для сканирования, например /mnt/unionfs/Media/Movies/Movie Name (year)', submitHint: 'Отправка добавляет путь в очередь сканирования', waitsBeforeTargets: ' · ожидает ', beforeTargetsAreCalled: ' перед вызовом целей' },
+    actions: { refresh: 'Обновить', submit: 'Отправить', copy: 'Копировать' },
+    stats: { queued: 'В очереди', queuedHint: 'Ожидание минимального времени', processed: 'Обработано', processedHint: 'Успешные обновления', targets: 'Цели', targetsHint: 'Plex / JF / Emby', minAge: 'Минимальное время', minAgeHint: 'Задержка перед сканированием' },
+    webhooks: { title: 'Webhook-и ARR', instructions: 'В Sonarr / Radarr / Lidarr: Настройки → Connect → Webhook → On Import + On Upgrade (а также удаление/переименование, если они тоже нужны). Используйте Basic Auth из Настройки → Scanner.' },
+    queue: { title: 'Очередь', subtitle: 'Пути, ожидающие минимального времени.', pending: 'Ожидают: {count}', empty: 'Очередь пуста — ожидание следующего webhook или ручного пути.' },
+    filters: { allConfiguredApps: 'Все настроенные приложения', allEvents: 'Все события', imports: 'Импорты', upgrades: 'Обновления', deleted: 'Удалённые', renames: 'Переименования', manual: 'Вручную', refresh: 'Обновить', other: 'Другое' },
+    activity: { title: 'Недавняя активность', subtitle: 'Последние {total} событий · {perPage} на страницу.', eventCount: 'Событий: {count}', noScansProcessed: 'Сканирования ещё не обработаны.', noEventsForSource: 'Нет событий {filter} для {source}.', noEvents: 'Нет событий {filter}.', noSourceActivity: 'Активность {source} не найдена.', ok: 'OK', error: 'Ошибка', targetSkipped: '{target}: пропущено', targetRefreshed: '{target}: обновлено', showing: 'Показано {from}–{to} из {total}', actions: { import: 'Импорт', upgrade: 'Обновление', fileDeleted: 'Файл удалён', seriesDeleted: 'Сериал удалён', movieDeleted: 'Фильм удалён', artistDeleted: 'Исполнитель удалён', rename: 'Переименовать', manual: 'Вручную', refresh: 'Обновить', other: 'Другое' } },
+    pagination: { previous: 'Назад', next: 'Далее' },
+    errors: { load: 'Не удалось загрузить Scanner', queuePath: 'Не удалось поставить путь в очередь' },
+    toasts: { queued: 'Добавлено в очередь: {path}', copied: 'Скопировано в буфер обмена' },
+} });
+
 Object.assign(ru, { settings: { ...ru.settings, logs: {
     actions: { refresh: 'Обновить', refreshing: 'Обновление...', exportAll: 'Экспортировать всё', exporting: 'Экспорт…', unblock: 'Разблокировать' },
     audit: { viewerTitle: 'Просмотр журнала аудита', empty: 'События аудита не найдены.', target: 'Цель', system: 'Система', actor: 'Исполнитель', field: 'Поле', before: 'До', after: 'После', value: 'Значение', unknownEvent: 'Событие' },

--- a/client/scanner/ScannerDashboard.tsx
+++ b/client/scanner/ScannerDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePoll } from '../shared/usePoll';
 import {
     ArrowUpCircle,
@@ -22,8 +22,10 @@ import {
 import { apiFetch } from '../shared/api';
 import { portalUrl } from '../shared/basePath';
 import { CustomSelect } from '../shared/ui';
+import { useDiscoverI18n } from '../discovery/i18n';
 import {
     formatScannerWhen,
+    SCANNER_ACTION_FILTER_LABEL_KEYS,
     SCANNER_ACTION_FILTER_LABELS,
     scannerActionFilterGroup,
     scannerActionStyles,
@@ -138,6 +140,9 @@ const EventCard: React.FC<{
 };
 
 export const ScannerDashboard: React.FC = () => {
+    const { t } = useDiscoverI18n();
+    const tRef = useRef(t);
+    tRef.current = t;
     const [path, setPath] = useState('');
     const [status, setStatus] = useState<ScannerStatus | null>(null);
     const [queue, setQueue] = useState<QueueItem[]>([]);
@@ -174,7 +179,7 @@ export const ScannerDashboard: React.FC = () => {
             setLog(Array.isArray(lg?.entries) ? lg.entries : []);
             setError(null);
         } catch (e: any) {
-            setError(e?.message || 'Failed to load scanner');
+            setError(e?.message || tRef.current('scanner.errors.load'));
         }
     }, []);
 
@@ -192,7 +197,7 @@ export const ScannerDashboard: React.FC = () => {
         return [...new Set([...configured, ...observed])];
     }, [status?.configuredSources, log]);
     const activitySourceOptions = useMemo(() => [
-        { value: 'all', label: 'All configured apps' },
+        { value: 'all', label: t('scanner.filters.allConfiguredApps') },
         ...configuredSources.map((source) => ({
             value: source,
             label: SOURCE_LABELS[source] || source,
@@ -208,7 +213,13 @@ export const ScannerDashboard: React.FC = () => {
                 <Cpu className="h-4 w-4 shrink-0 text-plex" />
             ) : undefined,
         })),
-    ], [configuredSources]);
+    ], [configuredSources, t]);
+    const activityEventLabel = useCallback((key: string) => {
+        const labelKey = SCANNER_ACTION_FILTER_LABEL_KEYS[key];
+        if (labelKey) return t(labelKey);
+        return SCANNER_ACTION_FILTER_LABELS[key]
+            || key.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+    }, [t]);
     const activityEventOptions = useMemo(() => {
         const present = new Set(
             log.map((entry) => scannerActionFilterGroup(entry.action || entry.reason, entry.isUpgrade)),
@@ -218,14 +229,13 @@ export const ScannerDashboard: React.FC = () => {
             if (!ordered.includes(key)) ordered.push(key);
         }
         return [
-            { value: 'all', label: SCANNER_ACTION_FILTER_LABELS.all },
+            { value: 'all', label: activityEventLabel('all') },
             ...ordered.map((key) => ({
                 value: key,
-                label: SCANNER_ACTION_FILTER_LABELS[key]
-                    || key.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+                label: activityEventLabel(key),
             })),
         ];
-    }, [log]);
+    }, [activityEventLabel, log]);
     const filteredLog = useMemo(() => {
         let rows = log;
         if (activitySource !== 'all') {
@@ -286,11 +296,11 @@ export const ScannerDashboard: React.FC = () => {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ path: value }),
             });
-            setMessage(`Queued: ${res.folder || value}`);
+            setMessage(t('scanner.toasts.queued', { path: res.folder || value }));
             setPath('');
             await refresh();
         } catch (err: any) {
-            setError(err?.message || 'Failed to queue path');
+            setError(err?.message || t('scanner.errors.queuePath'));
         } finally {
             setBusy(false);
         }
@@ -299,7 +309,7 @@ export const ScannerDashboard: React.FC = () => {
     const copyText = async (text: string) => {
         try {
             await navigator.clipboard.writeText(text);
-            setMessage('Copied to clipboard');
+            setMessage(t('scanner.toasts.copied'));
         } catch {
             setMessage(text);
         }
@@ -319,9 +329,9 @@ export const ScannerDashboard: React.FC = () => {
         <DashboardPageShell>
             <DashboardHero
                 accent="sky"
-                eyebrow="Library Scanner"
-                title="Refresh with precision"
-                description="Queue a folder for a partial library refresh on Plex, Jellyfin, or Emby. ARR webhooks land here automatically as imports, upgrades, deletes, and renames."
+                eyebrow={t('scanner.dashboard.eyebrow')}
+                title={t('scanner.dashboard.title')}
+                description={t('scanner.dashboard.description')}
                 icon={<Radar className="h-3.5 w-3.5" />}
                 actions={(
                     <button
@@ -329,7 +339,7 @@ export const ScannerDashboard: React.FC = () => {
                         onClick={() => void refresh()}
                         className="inline-flex items-center justify-center gap-2 rounded-xl border border-white/10 bg-black/20 px-4 py-2.5 text-sm font-semibold text-muted transition-colors hover:bg-white/5 hover:text-text"
                     >
-                        <RefreshCw className="h-4 w-4" /> Refresh
+                        <RefreshCw className="h-4 w-4" /> {t('scanner.actions.refresh')}
                     </button>
                 )}
             />
@@ -344,16 +354,16 @@ export const ScannerDashboard: React.FC = () => {
                 >
                     <div className="min-w-0">
                         <h2 className="text-sm font-bold uppercase tracking-wider text-muted transition-colors group-hover:text-sky-200">
-                            Manual path
+                            {t('scanner.manual.title')}
                         </h2>
                         <p className="mt-0.5 text-xs text-muted/80">
                             {manualCollapsed
-                                ? 'Hidden — click to queue a folder manually.'
-                                : 'Add a folder now — processed after the minimum age.'}
+                                ? t('scanner.manual.hiddenHint')
+                                : t('scanner.manual.visibleHint')}
                         </p>
                     </div>
                     <span className="mt-0.5 inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-white/10 px-2.5 py-1.5 text-xs font-semibold text-muted transition-colors group-hover:bg-white/5 group-hover:text-text">
-                        {manualCollapsed ? 'Show' : 'Hide'}
+                        {manualCollapsed ? t('common.show') : t('common.hide')}
                         <ChevronDown className={`h-4 w-4 transition-transform ${manualCollapsed ? '' : 'rotate-180'}`} />
                     </span>
                 </button>
@@ -364,7 +374,7 @@ export const ScannerDashboard: React.FC = () => {
                                 type="text"
                                 value={path}
                                 onChange={(e) => setPath(e.target.value)}
-                                placeholder="Path to scan e.g. /mnt/unionfs/Media/Movies/Movie Name (year)"
+                                placeholder={t('scanner.manual.placeholder')}
                                 className="flex-1 rounded-xl border border-white/10 bg-background/70 px-4 py-3 text-text placeholder:text-muted/60 focus:outline-none focus:ring-2 focus:ring-sky-400/30"
                             />
                             <button
@@ -373,12 +383,16 @@ export const ScannerDashboard: React.FC = () => {
                                 className="inline-flex items-center justify-center gap-2 rounded-xl bg-sky-400 px-5 py-3 font-bold text-black transition-colors hover:bg-sky-300 disabled:opacity-50"
                             >
                                 {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
-                                Submit
+                                {t('scanner.actions.submit')}
                             </button>
                         </div>
                         <div className="rounded-xl border border-sky-400/20 bg-sky-500/10 px-4 py-3 text-sm leading-relaxed text-sky-100/95">
-                            Submit adds the path to the scan queue
-                            {status?.minimumAge ? <> · waits <code className="text-sky-200">{status.minimumAge}</code> before targets are called</> : null}.
+                            {t('scanner.manual.submitHint')}
+                            {status?.minimumAge ? <>
+                                {t('scanner.manual.waitsBeforeTargets')}
+                                <code className="text-sky-200">{status.minimumAge}</code>
+                                {t('scanner.manual.beforeTargetsAreCalled')}
+                            </> : null}.
                         </div>
                     </form>
                 ) : null}
@@ -393,30 +407,30 @@ export const ScannerDashboard: React.FC = () => {
 
             <div className="grid grid-cols-2 gap-3 md:gap-4 xl:grid-cols-4">
                 <DashboardStatCard
-                    label="Queued"
+                    label={t('scanner.stats.queued')}
                     value={status?.remaining ?? '—'}
-                    hint="Waiting for min age"
+                    hint={t('scanner.stats.queuedHint')}
                     icon={<ListTodo className="h-4 w-4 text-amber-300" />}
                     glow={dashboardGlowClass('amber')}
                 />
                 <DashboardStatCard
-                    label="Processed"
+                    label={t('scanner.stats.processed')}
                     value={status?.processed ?? '—'}
-                    hint="Successful refreshes"
+                    hint={t('scanner.stats.processedHint')}
                     icon={<Layers className="h-4 w-4 text-emerald-300" />}
                     glow={dashboardGlowClass('emerald')}
                 />
                 <DashboardStatCard
-                    label="Targets"
+                    label={t('scanner.stats.targets')}
                     value={status?.targetCount ?? '—'}
-                    hint="Plex / JF / Emby"
+                    hint={t('scanner.stats.targetsHint')}
                     icon={<Target className="h-4 w-4 text-violet-300" />}
                     glow={dashboardGlowClass('violet')}
                 />
                 <DashboardStatCard
-                    label="Min age"
+                    label={t('scanner.stats.minAge')}
                     value={status?.minimumAge ?? '—'}
-                    hint="Delay before scan"
+                    hint={t('scanner.stats.minAgeHint')}
                     icon={<Clock3 className="h-4 w-4 text-sky-300" />}
                     glow={dashboardGlowClass('sky')}
                 />
@@ -425,10 +439,9 @@ export const ScannerDashboard: React.FC = () => {
             {status?.showWebhooks !== false ? (
             <section className="glass-card space-y-4 p-4 shadow-xl md:p-5">
                 <div>
-                    <h2 className="text-lg font-bold tracking-tight text-text">ARR webhooks</h2>
+                    <h2 className="text-lg font-bold tracking-tight text-text">{t('scanner.webhooks.title')}</h2>
                     <p className="mt-1 text-sm leading-relaxed text-muted">
-                        In Sonarr / Radarr / Lidarr: Settings → Connect → Webhook → On Import + On Upgrade
-                        (and delete/rename if you want those too). Use Basic Auth from Settings → Scanner.
+                        {t('scanner.webhooks.instructions')}
                     </p>
                 </div>
                 <div className="grid grid-cols-1 gap-2.5 lg:grid-cols-2">
@@ -445,7 +458,7 @@ export const ScannerDashboard: React.FC = () => {
                                     type="button"
                                     onClick={() => void copyText(full)}
                                     className="rounded-lg border border-transparent p-2 text-muted transition-colors hover:border-white/10 hover:bg-white/10 hover:text-text"
-                                    title="Copy"
+                                    title={t('scanner.actions.copy')}
                                 >
                                     <Copy className="h-4 w-4" />
                                 </button>
@@ -458,17 +471,17 @@ export const ScannerDashboard: React.FC = () => {
 
             <div className="grid grid-cols-1 gap-4 md:gap-5 xl:grid-cols-2">
                 <DashboardPanel
-                    title="Queue"
-                    subtitle="Paths waiting for the minimum age."
+                    title={t('scanner.queue.title')}
+                    subtitle={t('scanner.queue.subtitle')}
                     badge={(
                         <span className="rounded-full border border-amber-400/25 bg-amber-500/10 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-amber-200">
-                            {queue.length} pending
+                            {t('scanner.queue.pending', { count: queue.length })}
                         </span>
                     )}
                 >
                     {queue.length === 0 ? (
                         <div className="rounded-xl border border-dashed border-white/10 bg-black/20 px-4 py-10 text-center">
-                            <p className="text-sm text-muted">Queue is empty — waiting for the next webhook or manual path.</p>
+                            <p className="text-sm text-muted">{t('scanner.queue.empty')}</p>
                         </div>
                     ) : (
                         <ul className="space-y-2">
@@ -479,7 +492,7 @@ export const ScannerDashboard: React.FC = () => {
                                         <div className="mb-2 flex flex-wrap items-center gap-2">
                                             <span className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${style.className}`}>
                                                 <ActionIcon action={item.action} className="h-3 w-3" />
-                                                {item.reason || style.label}
+                                                {item.reason || (style.labelKey ? t(style.labelKey) : style.label)}
                                             </span>
                                             <ScannerSourceBadge source={item.source} />
                                             <span className="ml-auto text-[10px] tabular-nums text-muted">P{item.priority ?? 0}</span>
@@ -501,8 +514,8 @@ export const ScannerDashboard: React.FC = () => {
                 </DashboardPanel>
 
                 <DashboardPanel
-                    title="Recent activity"
-                    subtitle={`Latest ${ACTIVITY_FETCH_LIMIT} events · ${ACTIVITY_PAGE_SIZE} per page.`}
+                    title={t('scanner.activity.title')}
+                    subtitle={t('scanner.activity.subtitle', { total: ACTIVITY_FETCH_LIMIT, perPage: ACTIVITY_PAGE_SIZE })}
                     controls={(
                         <div className="flex w-full min-w-0 flex-nowrap items-center gap-2 sm:w-auto">
                             {configuredSources.length > 0 ? (
@@ -524,7 +537,7 @@ export const ScannerDashboard: React.FC = () => {
                                 className="min-w-0 flex-1 sm:w-40 sm:flex-none"
                             />
                             <span className="shrink-0 whitespace-nowrap rounded-full border border-emerald-400/25 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-emerald-200">
-                                {filteredLog.length} events
+                                {t('scanner.activity.eventCount', { count: filteredLog.length })}
                             </span>
                         </div>
                     )}
@@ -533,10 +546,19 @@ export const ScannerDashboard: React.FC = () => {
                         <div className="rounded-xl border border-dashed border-white/10 bg-black/20 px-4 py-10 text-center">
                             <p className="text-sm text-muted">
                                 {log.length === 0
-                                    ? 'No scans processed yet.'
+                                    ? t('scanner.activity.noScansProcessed')
                                     : activityEvent !== 'all'
-                                        ? `No ${SCANNER_ACTION_FILTER_LABELS[activityEvent] || activityEvent} events${activitySource !== 'all' ? ` for ${SOURCE_LABELS[activitySource] || activitySource}` : ''}.`
-                                        : `No ${SOURCE_LABELS[activitySource] || activitySource} activity found.`}
+                                        ? activitySource !== 'all'
+                                            ? t('scanner.activity.noEventsForSource', {
+                                                filter: activityEventLabel(activityEvent),
+                                                source: SOURCE_LABELS[activitySource] || activitySource,
+                                            })
+                                            : t('scanner.activity.noEvents', {
+                                                filter: activityEventLabel(activityEvent),
+                                            })
+                                        : t('scanner.activity.noSourceActivity', {
+                                            source: SOURCE_LABELS[activitySource] || activitySource,
+                                        })}
                             </p>
                         </div>
                     ) : (
@@ -554,11 +576,11 @@ export const ScannerDashboard: React.FC = () => {
                                                     ? 'border-emerald-400/30 bg-emerald-500/15 text-emerald-300'
                                                     : 'border-red-400/30 bg-red-500/15 text-red-300'
                                             }`}>
-                                                {entry.ok ? 'OK' : 'Error'}
+                                                {entry.ok ? t('scanner.activity.ok') : t('scanner.activity.error')}
                                             </span>
                                             <span className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${style.className}`}>
                                                 <ActionIcon action={entry.action} className="h-3 w-3" />
-                                                {entry.reason || style.label}
+                                                {entry.reason || (style.labelKey ? t(style.labelKey) : style.label)}
                                             </span>
                                             <ScannerSourceBadge source={entry.source} />
                                             <span className="ml-auto text-[10px] text-muted">{formatScannerWhen(entry.at)}</span>
@@ -574,8 +596,8 @@ export const ScannerDashboard: React.FC = () => {
                                                 <span>
                                                     {targets.map((r: any) => (
                                                         r?.skipped
-                                                            ? `${r.type}: skipped`
-                                                            : `${r.type}: refreshed`
+                                                            ? t('scanner.activity.targetSkipped', { target: r.type })
+                                                            : t('scanner.activity.targetRefreshed', { target: r.type })
                                                     )).join(' · ')}
                                                 </span>
                                             ) : null}
@@ -588,7 +610,7 @@ export const ScannerDashboard: React.FC = () => {
                         {filteredLog.length > ACTIVITY_PAGE_SIZE ? (
                             <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-xl border border-white/10 bg-black/20 px-3 py-2.5">
                                 <p className="text-xs text-muted">
-                                    Showing {activitySafePage * ACTIVITY_PAGE_SIZE + 1}–{Math.min(filteredLog.length, (activitySafePage + 1) * ACTIVITY_PAGE_SIZE)} of {filteredLog.length}
+                                    {t('scanner.activity.showing', { from: activitySafePage * ACTIVITY_PAGE_SIZE + 1, to: Math.min(filteredLog.length, (activitySafePage + 1) * ACTIVITY_PAGE_SIZE), total: filteredLog.length })}
                                 </p>
                                 <div className="flex items-center gap-2">
                                     <button
@@ -598,7 +620,7 @@ export const ScannerDashboard: React.FC = () => {
                                         onClick={() => setActivityPage((p) => Math.max(0, p - 1))}
                                     >
                                         <ChevronLeft className="h-3.5 w-3.5" />
-                                        Prev
+                                        {t('scanner.pagination.previous')}
                                     </button>
                                     <span className="text-xs font-semibold tabular-nums text-muted">
                                         {activitySafePage + 1} / {activityTotalPages}
@@ -609,7 +631,7 @@ export const ScannerDashboard: React.FC = () => {
                                         disabled={activitySafePage >= activityTotalPages - 1}
                                         onClick={() => setActivityPage((p) => Math.min(activityTotalPages - 1, p + 1))}
                                     >
-                                        Next
+                                        {t('scanner.pagination.next')}
                                         <ChevronRight className="h-3.5 w-3.5" />
                                     </button>
                                 </div>

--- a/client/scanner/eventMeta.ts
+++ b/client/scanner/eventMeta.ts
@@ -61,8 +61,21 @@ export const SCANNER_ACTION_FILTER_LABELS: Record<string, string> = {
     other: 'Other',
 };
 
+/** Translation keys for stable activity-filter buckets. */
+export const SCANNER_ACTION_FILTER_LABEL_KEYS: Record<string, string> = {
+    all: 'scanner.filters.allEvents',
+    import: 'scanner.filters.imports',
+    upgrade: 'scanner.filters.upgrades',
+    deleted: 'scanner.filters.deleted',
+    rename: 'scanner.filters.renames',
+    manual: 'scanner.filters.manual',
+    refresh: 'scanner.filters.refresh',
+    other: 'scanner.filters.other',
+};
+
 export const scannerActionStyles = (action?: string, isUpgrade?: boolean): {
     label: string;
+    labelKey?: string;
     className: string;
     iconTone: string;
 } => {
@@ -71,60 +84,70 @@ export const scannerActionStyles = (action?: string, isUpgrade?: boolean): {
         case 'import':
             return {
                 label: 'Import',
+                labelKey: 'scanner.activity.actions.import',
                 className: 'bg-emerald-500/15 text-emerald-300 border-emerald-400/30',
                 iconTone: 'text-emerald-300',
             };
         case 'upgrade':
             return {
                 label: 'Upgrade',
+                labelKey: 'scanner.activity.actions.upgrade',
                 className: 'bg-amber-500/15 text-amber-300 border-amber-400/30',
                 iconTone: 'text-amber-300',
             };
         case 'file-delete':
             return {
                 label: 'File deleted',
+                labelKey: 'scanner.activity.actions.fileDeleted',
                 className: 'bg-rose-500/15 text-rose-300 border-rose-400/30',
                 iconTone: 'text-rose-300',
             };
         case 'series-delete':
             return {
                 label: 'Series deleted',
+                labelKey: 'scanner.activity.actions.seriesDeleted',
                 className: 'bg-rose-500/15 text-rose-300 border-rose-400/30',
                 iconTone: 'text-rose-300',
             };
         case 'movie-delete':
             return {
                 label: 'Movie deleted',
+                labelKey: 'scanner.activity.actions.movieDeleted',
                 className: 'bg-rose-500/15 text-rose-300 border-rose-400/30',
                 iconTone: 'text-rose-300',
             };
         case 'artist-delete':
             return {
                 label: 'Artist deleted',
+                labelKey: 'scanner.activity.actions.artistDeleted',
                 className: 'bg-rose-500/15 text-rose-300 border-rose-400/30',
                 iconTone: 'text-rose-300',
             };
         case 'rename':
             return {
                 label: 'Rename',
+                labelKey: 'scanner.activity.actions.rename',
                 className: 'bg-violet-500/15 text-violet-300 border-violet-400/30',
                 iconTone: 'text-violet-300',
             };
         case 'manual':
             return {
                 label: 'Manual',
+                labelKey: 'scanner.activity.actions.manual',
                 className: 'bg-sky-500/15 text-sky-300 border-sky-400/30',
                 iconTone: 'text-sky-300',
             };
         case 'refresh':
             return {
                 label: 'Refresh',
+                labelKey: 'scanner.activity.actions.refresh',
                 className: 'bg-plex/15 text-plex border-plex/30',
                 iconTone: 'text-plex',
             };
         default:
             return {
                 label: key === 'other' ? 'Other' : key.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+                labelKey: key === 'other' ? 'scanner.activity.actions.other' : undefined,
                 className: 'bg-white/10 text-muted border-white/15',
                 iconTone: 'text-muted',
             };


### PR DESCRIPTION
## Summary

Localizes the active Scanner dashboard using the existing Discover i18n system.

This includes:

- Scanner dashboard headings, descriptions, actions, stats, queue and activity UI
- Manual path submission UI
- Webhook instructions and related actions
- Pagination, loading, empty, error and toast states
- Scanner event filter labels
- Scanner activity/action display labels
- Explicit translations across all 10 supported locales:
  - English
  - French
  - German
  - Spanish
  - Portuguese (Brazil)
  - Italian
  - Japanese
  - Polish
  - Dutch
  - Russian

Internal Scanner values remain unchanged. Translation keys are display-only, while filter IDs, event values, source identifiers, API values and other internal identifiers continue using their existing stable values.

Unknown/dynamic activity actions retain the existing English fallback behavior.

## Scope

This PR intentionally covers the Scanner dashboard only.

Scanner Settings and its embedded Live Activity UI are left unchanged and will be handled separately, so Scanner remains marked as `Partial` in the translation status.

## Validation

- 64 `scanner.*` keys in each of the 10 supported locales
- Missing keys: 0
- Extra keys: 0
- Placeholder mismatches: 0
- `npm.cmd test`: 58 passed, 0 failed
- `npm.cmd run build:js`: passed
- `git diff --check`: passed
- No backend or Scanner Settings changes

The existing Poster Sets duplicate-key build warnings remain unrelated to this PR.