### PR TITLE
feat(i18n): complete Scanner localization

### DIFF
--- a/client/scanner/ScannerHomeWidget.tsx
+++ b/client/scanner/ScannerHomeWidget.tsx
@@ -195,7 +195,7 @@ export const ScannerHomeWidget: React.FC<Props> = ({ onOpen }) => {
                                     </span>
                                     {(last.reason || last.action) ? (
                                         <span className={`text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md border ${lastStyle.className}`}>
-                                            {last.reason || lastStyle.label}
+                                            {last.reason || (lastStyle.labelKey ? t(lastStyle.labelKey) : lastStyle.label)}
                                         </span>
                                     ) : null}
                                     <ScannerSourceBadge source={last.source} className="ml-0.5" />

--- a/client/scanner/ScannerSourceBadge.tsx
+++ b/client/scanner/ScannerSourceBadge.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Cpu, FolderInput } from 'lucide-react';
+import { useDiscoverI18n } from '../discovery/i18n';
 import { sourceAppIconUrl, sourceAppKey, sourceAppLabel } from './eventMeta';
 
 type Props = {
@@ -8,9 +9,10 @@ type Props = {
 };
 
 export const ScannerSourceBadge: React.FC<Props> = ({ source, className = '' }) => {
-    const label = sourceAppLabel(source);
-    if (!label) return null;
     const key = sourceAppKey(source);
+    const { t } = useDiscoverI18n();
+    const label = key === 'manual' ? t('scanner.filters.manual') : sourceAppLabel(source);
+    if (!label) return null;
     const iconUrl = sourceAppIconUrl(source);
 
     return (

--- a/docs/development/translation-status.md
+++ b/docs/development/translation-status.md
@@ -36,7 +36,7 @@ This table describes broad UI i18n wiring and known remaining work. It does not 
 | Status page | i18n-enabled |
 | Support tickets | i18n-enabled |
 | Wider Settings | Partial |
-| Scanner | Partial |
+| Scanner | i18n-enabled |
 | ColleXions | Partial |
 | Media Automation | Partial |
 | Poster Sets | Partial |


### PR DESCRIPTION
## Summary

Completes the remaining Scanner localization work by reusing the existing i18n keys in the final Scanner UI components.

This PR updates:

- `ScannerHomeWidget.tsx`
- `ScannerSourceBadge.tsx`
- `docs/development/translation-status.md`

## Changes

### Scanner Home Widget

Known Scanner activity actions now use their existing translation keys through `labelKey`.

Unknown or dynamic actions still fall back to the existing raw label.

### Scanner Source Badge

The stable `Manual` source label now uses the existing:

`scanner.filters.manual`

Product and dynamic source labels remain unchanged:

- Sonarr
- Radarr
- Lidarr
- Media Automation
- unknown/dynamic source values

## Translation keys

No new translation keys are introduced.

This PR only reuses keys that already exist across all 10 supported locales.

## Behavior

This is display-layer localization only.

No changes were made to:

- polling
- Scanner API calls
- queue behavior
- navigation
- action/source classification
- source identifiers
- backend values
- timestamps
- paths
- dynamic fallbacks
- component APIs or styling

## Validation

- `npm test` — 58/58 passed
- `npm run build:js` — passed
- `npm run build` — passed
- `git diff --check` — passed
- Existing reused translation keys confirmed in all 10 supported locales
- No remaining ordinary hardcoded Scanner UI chrome found

The builds still report the existing unrelated Poster Sets duplicate-key warnings for:

- `watchesCategoryFilter`
- `setWatchesCategoryFilter`

## Translation status

The focused Scanner audit confirms that the remaining rendered Scanner UI is now covered by i18n.

This PR therefore updates:

`Scanner | Partial`

to:

`Scanner | i18n-enabled`