### PR TITLE
fix(i18n): restore mobile navigation labels

### DIFF
--- a/client/screens.tsx
+++ b/client/screens.tsx
@@ -12422,7 +12422,7 @@ export const Navigation: React.FC<NavigationProps> = ({ currentRoute, onNavigate
                             const item = navItemsConfig[key];
                             if (!item) return null;
                             const isCurrent = item.route ? isNavCurrent(key, item.route) : false;
-                            const labelOverride = key === 'mediastack' ? 'Calendar' : key === 'request' ? 'Request' : item.label;
+                            const labelOverride = key === 'mediastack' ? t('navigation.calendar') : key === 'request' ? t('navigation.request') : item.label;
                             return renderNavAction(key, { ...item, label: labelOverride }, { mobile: true, isCurrent, compactLabel: labelOverride, badgeCount: getNavBadgeCount(key) });
                         })}
                         {showMore && (
@@ -12436,7 +12436,7 @@ export const Navigation: React.FC<NavigationProps> = ({ currentRoute, onNavigate
                                 <span className="relative shrink-0">
                                     <MoreHorizontal className="w-5 h-5" />
                                 </span>
-                                <span>More</span>
+                                <span>{t('navigation.more')}</span>
                             </button>
                         )}
                     </>
@@ -12479,7 +12479,7 @@ export const Navigation: React.FC<NavigationProps> = ({ currentRoute, onNavigate
                 <div className="md:hidden fixed inset-0 z-[320] bg-black/60 backdrop-blur-sm animate-fade-in flex flex-col justify-end" onClick={() => setMobileMoreOpen(false)}>
                     <div className="bg-card border-t border-border rounded-t-2xl animate-slide-up" onClick={e => e.stopPropagation()}>
                         <div className="flex items-center justify-between p-4 border-b border-white/5">
-                            <h3 className="font-bold text-text">More Menu</h3>
+                            <h3 className="font-bold text-text">{t('navigation.moreMenu')}</h3>
                             <button className="text-muted hover:text-text p-1 bg-white/5 rounded-full" onClick={() => setMobileMoreOpen(false)}><X className="w-5 h-5" /></button>
                         </div>
                         <div className="p-5 grid grid-cols-4 gap-4">
@@ -12490,7 +12490,7 @@ export const Navigation: React.FC<NavigationProps> = ({ currentRoute, onNavigate
                                     const item = navItemsConfig[key];
                                     if (!item) return null;
                                     const isCurrent = item.route ? isNavCurrent(key, item.route) : false;
-                                    const labelOverride = key === 'mediastack' ? 'Calendar' : key === 'request' ? 'Request' : item.label;
+                                    const labelOverride = key === 'mediastack' ? t('navigation.calendar') : key === 'request' ? t('navigation.request') : item.label;
                                     const handleActivate = () => {
                                         setMobileMoreOpen(false);
                                         if (item.href) window.open(item.href, '_blank');


### PR DESCRIPTION
## Summary

Restores localized labels in the mobile navigation after a recent navigation refactor introduced hardcoded English display text.

## Changes

Replaces hardcoded mobile navigation labels with the existing i18n keys:

- `Calendar` → `navigation.calendar`
- member `Request` → `navigation.request`
- `More` → `navigation.more`
- `More Menu` → `navigation.moreMenu`

Admin `Requests` remains correctly wired to:

`navigation.requests`

## Scope

This fix only updates:

- `client/screens.tsx`

No locale catalogs or translation keys are added because the required keys already exist.

## Behavior

This is display-layer only.

No changes were made to:

- routes
- navigation targets
- ordering
- permissions
- admin/member visibility
- active-state logic
- badges
- icons
- click handlers
- drawer behavior
- mobile layout or styling
- desktop navigation

## Validation

- `npm test` — 58/58 passed
- `npm run build:js` — passed
- `npm run build` — passed
- `git diff --check` — passed

The builds still report the existing unrelated Poster Sets duplicate-key warnings for:

- `watchesCategoryFilter`
- `setWatchesCategoryFilter`

## Context

This is the first focused repair from a wider i18n regression audit.

Other newly introduced untranslated UI areas are intentionally excluded and will be handled separately to keep this PR small and easy to review.