### PR TITLE
fix(i18n): localize Discover quick actions label

### DIFF
--- a/client/discovery/i18n/de.ts
+++ b/client/discovery/i18n/de.ts
@@ -458,6 +458,8 @@ Object.assign(de, { maintenance: { ...de.maintenance,
     calendar: { currentRule: 'Aktuelle Regel:', graceDays: 'Karenztage', ruleAge: 'Regelalter', eligibleNow: 'Jetzt berechtigt', laterReclaim: 'Spätere Rückgewinnung', daysUntilEligible: 'Tag(e) bis zur Berechtigung', titleCount: 'Titel', laterDetail: 'Diese Titel warten noch auf das Ende der Karenzzeit.', dateTitleCount: 'Anzahl der Titel für dieses Datum.', delayedReclaimTooltip: 'Schätzung der Rückgewinnung aus verzögerten Treffern.', eligibilityDetailTooltip: 'Berechtigungsdetails des Backends.', ago: 'Tage zuvor', notAvailable: 'n/v', ...de.maintenance.calendar }
 } });
 
+Object.assign(de, { quickActions: { menuLabel: 'Schnellaktionen' } });
+
 Object.assign(de, { homeDashboard: { ...de.homeDashboard, opsSnapshot: {
     title: 'Betriebsübersicht',
     loading: 'Betriebsübersicht wird geladen…',

--- a/client/discovery/i18n/en.ts
+++ b/client/discovery/i18n/en.ts
@@ -311,6 +311,7 @@ export const en = {
         openMediaAutomation: 'Open Media Automation',
     },
     quickActions: {
+        menuLabel: 'Quick actions',
         request: 'Request',
         requestHint: 'Opening request details…',
         notify: 'Notify me',

--- a/client/discovery/i18n/es.ts
+++ b/client/discovery/i18n/es.ts
@@ -462,6 +462,8 @@ Object.assign(es, { maintenance: { ...es.maintenance,
     errors: { loadOverview: 'No se pudo cargar el resumen de limpieza', loadCandidates: 'No se pudieron cargar los candidatos', loadExclusions: 'No se pudo cargar el resumen de exclusiones.', loadLibrary: 'No se pudieron cargar los pósteres de la biblioteca.', loadStorage: 'No se pudo cargar el resumen de almacenamiento.' }
 } });
 
+Object.assign(es, { quickActions: { menuLabel: 'Acciones rápidas' } });
+
 Object.assign(es, { homeDashboard: { ...es.homeDashboard, opsSnapshot: {
     title: 'Resumen operativo',
     loading: 'Cargando resumen operativo…',

--- a/client/discovery/i18n/fr.ts
+++ b/client/discovery/i18n/fr.ts
@@ -313,6 +313,7 @@ export const fr: DeepPartial<EnCatalog> = {
         openMediaAutomation: 'Ouvrir Automatisation média',
     },
     quickActions: {
+        menuLabel: 'Actions rapides',
         request: 'Demander',
         requestHint: 'Ouverture des details de demande…',
         notify: 'Notifier',

--- a/client/discovery/i18n/it.ts
+++ b/client/discovery/i18n/it.ts
@@ -44,6 +44,8 @@ Object.assign(it, { maintenance: { ...it.maintenance,
     errors: { loadOverview: 'Impossibile caricare il riepilogo della pulizia', loadCandidates: 'Impossibile caricare i candidati', loadExclusions: 'Impossibile caricare il riepilogo delle esclusioni.', loadLibrary: 'Impossibile caricare i poster della libreria.', loadStorage: 'Impossibile caricare il riepilogo dello spazio.' }
 } });
 
+Object.assign(it, { quickActions: { menuLabel: 'Azioni rapide' } });
+
 Object.assign(it, { homeDashboard: { ...it.homeDashboard, opsSnapshot: {
     title: 'Riepilogo operativo',
     loading: 'Caricamento del riepilogo operativo…',

--- a/client/discovery/i18n/ja.ts
+++ b/client/discovery/i18n/ja.ts
@@ -44,6 +44,8 @@ Object.assign(ja, { maintenance: { ...ja.maintenance,
     errors: { loadOverview: 'クリーナー概要を読み込めませんでした', loadCandidates: '候補を読み込めませんでした', loadExclusions: '除外の概要を読み込めませんでした。', loadLibrary: 'ライブラリのポスターを読み込めませんでした。', loadStorage: 'ストレージ概要を読み込めませんでした。' }
 } });
 
+Object.assign(ja, { quickActions: { menuLabel: 'クイックアクション' } });
+
 Object.assign(ja, { homeDashboard: { ...ja.homeDashboard, opsSnapshot: {
     title: '運用スナップショット',
     loading: '運用スナップショットを読み込み中…',

--- a/client/discovery/i18n/nl.ts
+++ b/client/discovery/i18n/nl.ts
@@ -44,6 +44,8 @@ Object.assign(nl, { maintenance: { ...nl.maintenance,
     errors: { loadOverview: 'Overzicht van opschonen kon niet worden geladen', loadCandidates: 'Kandidaten konden niet worden geladen', loadExclusions: 'Samenvatting van uitsluitingen kon niet worden geladen.', loadLibrary: 'Bibliotheekposters konden niet worden geladen.', loadStorage: 'Opslagsamenvatting kon niet worden geladen.' }
 } });
 
+Object.assign(nl, { quickActions: { menuLabel: 'Snelle acties' } });
+
 Object.assign(nl, { homeDashboard: { ...nl.homeDashboard, opsSnapshot: {
     title: 'Operationeel overzicht',
     loading: 'Operationeel overzicht laden…',

--- a/client/discovery/i18n/pl.ts
+++ b/client/discovery/i18n/pl.ts
@@ -44,6 +44,8 @@ Object.assign(pl, { maintenance: { ...pl.maintenance,
     errors: { loadOverview: 'Nie udało się wczytać przeglądu czyszczenia', loadCandidates: 'Nie udało się wczytać kandydatów', loadExclusions: 'Nie udało się wczytać podsumowania wykluczeń.', loadLibrary: 'Nie udało się wczytać plakatów biblioteki.', loadStorage: 'Nie udało się wczytać podsumowania pamięci.' }
 } });
 
+Object.assign(pl, { quickActions: { menuLabel: 'Szybkie akcje' } });
+
 Object.assign(pl, { homeDashboard: { ...pl.homeDashboard, opsSnapshot: {
     title: 'Podsumowanie operacyjne',
     loading: 'Wczytywanie podsumowania operacyjnego…',

--- a/client/discovery/i18n/pt-BR.ts
+++ b/client/discovery/i18n/pt-BR.ts
@@ -44,6 +44,8 @@ Object.assign(ptBR, { maintenance: { ...ptBR.maintenance,
     errors: { loadOverview: 'Não foi possível carregar o resumo da limpeza', loadCandidates: 'Não foi possível carregar os candidatos', loadExclusions: 'Não foi possível carregar o resumo das exclusões.', loadLibrary: 'Não foi possível carregar os pôsteres da biblioteca.', loadStorage: 'Não foi possível carregar o resumo do armazenamento.' }
 } });
 
+Object.assign(ptBR, { quickActions: { menuLabel: 'Ações rápidas' } });
+
 Object.assign(ptBR, { homeDashboard: { ...ptBR.homeDashboard, opsSnapshot: {
     title: 'Resumo operacional',
     loading: 'Carregando resumo operacional…',

--- a/client/discovery/i18n/ru.ts
+++ b/client/discovery/i18n/ru.ts
@@ -44,6 +44,8 @@ Object.assign(ru, { maintenance: { ...ru.maintenance,
     errors: { loadOverview: 'Не удалось загрузить обзор очистки', loadCandidates: 'Не удалось загрузить кандидатов', loadExclusions: 'Не удалось загрузить сводку исключений.', loadLibrary: 'Не удалось загрузить постеры библиотеки.', loadStorage: 'Не удалось загрузить сводку хранилища.' }
 } });
 
+Object.assign(ru, { quickActions: { menuLabel: 'Быстрые действия' } });
+
 Object.assign(ru, { homeDashboard: { ...ru.homeDashboard, opsSnapshot: {
     title: 'Оперативная сводка',
     loading: 'Загрузка оперативной сводки…',

--- a/client/screens.tsx
+++ b/client/screens.tsx
@@ -7090,6 +7090,7 @@ export const DiscoverPosterCard: React.FC<{
     posterWidth?: number;
     posterHeight?: number;
 }> = ({ item, aspect, overlay, variant = 'discover', className = 'w-full', footer, showQualityBadges = true, posterOnlyLink = false, onPosterClick, onPosterHover, quickActions, posterWidth = 300, posterHeight }) => {
+    const { t } = useDiscoverI18n();
     const resolvedAspect = aspect ?? (
         item?.mediaType === 'music' || item?.type === 'music' ? 'square' : '2/3'
     );
@@ -7169,7 +7170,7 @@ export const DiscoverPosterCard: React.FC<{
                                 setQuickActionsOpen((open) => !open);
                             }}
                             className="inline-flex items-center justify-center w-7 h-7 rounded-md bg-black/65 text-white/90 border border-white/20 hover:bg-black/80 hover:text-white transition-colors"
-                            aria-label="Quick actions"
+                            aria-label={t('quickActions.menuLabel')}
                             aria-expanded={quickActionsOpen}
                         >
                             <MoreHorizontal className="w-4 h-4" />


### PR DESCRIPTION
## Summary

Localizes the shared Discover poster quick-actions accessibility label.

The icon button previously used the hardcoded English accessible name:

`Quick actions`

It now uses the existing Discover i18n system with:

`quickActions.menuLabel`

## Changes

- replaces the hardcoded `aria-label="Quick actions"` with `t('quickActions.menuLabel')`
- adds `quickActions.menuLabel` to all 10 supported locale catalogs
- keeps the existing root `quickActions.*` namespace

Supported locales:

- English
- French
- German
- Spanish
- Brazilian Portuguese
- Italian
- Japanese
- Polish
- Dutch
- Russian

## Accessibility

This change only localizes the button's accessible name.

No changes were made to:

- native button semantics
- `aria-expanded`
- click handlers
- event propagation
- keyboard behavior
- focus behavior
- Escape dismissal
- outside-click dismissal
- hover/pointer behavior
- icon rendering
- overlay visibility

## Scope

The shared quick-actions button is rendered by `DiscoverPosterCard` in `client/screens.tsx`.

`DiscoverPosterGrid.tsx` only forwards the `quickActions` data and is intentionally unchanged.

Existing action translations such as:

- `quickActions.request`
- `quickActions.notify`
- `quickActions.openInPlex`
- `quickActions.hide`
- `quickActions.unhide`

remain untouched.

## Validation

- `npm test` — 58/58 passed
- `npm run build:js` — passed
- `git diff --check` — passed
- `quickActions.menuLabel` confirmed in all 10 supported locales
- no remaining hardcoded `Quick actions` accessibility label found

The build still reports the existing unrelated Poster Sets duplicate-key warnings for:

- `watchesCategoryFilter`
- `setWatchesCategoryFilter`