### PR TITLE
feat(i18n): localize Stream Kill Rules

### DIFF
--- a/client/discovery/i18n/de.ts
+++ b/client/discovery/i18n/de.ts
@@ -474,6 +474,25 @@ Object.assign(de, { homeDashboard: { ...de.homeDashboard, opsSnapshot: {
     empty: { noIncidents: 'Keine Vorfälle', unavailable: 'Betriebsübersicht nicht verfügbar.' },
 } } });
 
+Object.assign(de, { settings: { ...de.settings, streamKillRules: {
+    title: 'Stream-Abbruchregeln',
+    description: { beforeInterval: 'Lege Regeln fest, die Plex-Streams automatisch beenden. Regeln werden alle ', interval: '15 Sekunden', afterInterval: ' ausgewertet. Kombiniere Bedingungen mit ', andAllMatch: ' (alle müssen zutreffen) oder ', orAnyMatch: ' (mindestens eine muss zutreffen). ', afterLogic: 'Die Abbruchmeldung erscheint auf dem Plex-Client des Benutzers.' },
+    fields: { isTranscoding: 'Wird transkodiert', videoResolution: 'Videoauflösung', transcodeVideoDecision: 'Transkodierungsentscheidung', mediaType: 'Medientyp', state: 'Wiedergabestatus', sessionLocation: 'Verbindungsstandort', videoCodec: 'Videocodec', audioCodec: 'Audiocodec', bandwidth: 'Bandbreite (Mbps)', user: 'Benutzername', playerProduct: 'Player-App', playerTitle: 'Player-/Gerätename' },
+    operators: { equals: 'gleich', not_equals: 'ungleich', contains: 'enthält', not_contains: 'enthält nicht', greater_than: 'größer als', less_than: 'kleiner als', is: 'ist' },
+    boolean: { yesTrue: 'Ja / Wahr', noFalse: 'Nein / Falsch' },
+    options: { transcode: 'Transkodieren', copy: 'Kopieren', directplay: 'Direktwiedergabe', movie: 'Film', episode: 'Folge', track: 'Titel', playing: 'Wird wiedergegeben', paused: 'Pausiert', buffering: 'Puffert', cellular: 'Mobilfunk' },
+    placeholders: { numberExample: 'z. B. 20', playerExample: 'z. B. Plex Web', ruleName: 'Regelname...' },
+    empty: { title: 'Keine Regeln konfiguriert', description: 'Füge unten eine Regel hinzu, um deinen Server automatisch zu schützen.' },
+    rule: { conditionCount: '{count} Bedingung', conditionCount_plural: '{count} Bedingungen', logic: 'Logik:' },
+    status: { active: 'Aktiv', disabled: 'Deaktiviert' },
+    logic: { and: 'UND', or: 'ODER' },
+    match: { title: 'Abgleichen', followingConditions: 'der folgenden Bedingungen' },
+    actions: { remove: 'Entfernen', delete: 'Löschen', addCondition: 'Bedingung hinzufügen', addRule: 'Neue Regel hinzufügen', saveRules: 'Regeln speichern' },
+    editor: { killMessage: 'Abbruchmeldung', killMessageHint: '(wird im Plex-Client des Benutzers angezeigt)', killMessagePlaceholder: 'Dein Stream wurde vom Serveradministrator beendet.' },
+    toasts: { loadFailed: 'Regeln konnten nicht geladen werden', saved: 'Stream-Regeln gespeichert!', saveFailed: 'Regeln konnten nicht gespeichert werden' },
+    defaults: { newRuleName: 'Neue Regel', killMessage: 'Dein Stream wurde vom Serveradministrator beendet.' },
+} } });
+
 Object.assign(de, { homeDashboard: { ...de.homeDashboard, nowPlayingCompanion: {
     ...de.homeDashboard.nowPlayingCompanion,
     timeline: { release: 'Veröffentlichung', runtime: 'Laufzeit', episodeRuntime: 'Folgenlaufzeit', genres: 'Genres', tmdbScore: 'TMDB-Bewertung', status: 'Status', currentEpisode: 'Aktuelle Folge', episodeAirDate: 'Ausstrahlungsdatum der Folge' },

--- a/client/discovery/i18n/en.ts
+++ b/client/discovery/i18n/en.ts
@@ -2120,6 +2120,25 @@ Object.assign(en, { settings: { ...en.settings, homeLayout: {
     },
 } } });
 
+Object.assign(en, { settings: { ...en.settings, streamKillRules: {
+    title: 'Stream Kill Rules',
+    description: { beforeInterval: 'Define rules that automatically terminate Plex streams. Rules are evaluated every ', interval: '15 seconds', afterInterval: '. Combine conditions using ', andAllMatch: ' (all must match) or ', orAnyMatch: ' (any must match). ', afterLogic: "The kill message appears on the user's Plex client screen." },
+    fields: { isTranscoding: 'Is Transcoding', videoResolution: 'Video Resolution', transcodeVideoDecision: 'Transcode Decision', mediaType: 'Media Type', state: 'Playback State', sessionLocation: 'Connection Location', videoCodec: 'Video Codec', audioCodec: 'Audio Codec', bandwidth: 'Bandwidth (Mbps)', user: 'Username', playerProduct: 'Player App', playerTitle: 'Player/Device Name' },
+    operators: { equals: 'equals', not_equals: 'not equals', contains: 'contains', not_contains: "doesn't contain", greater_than: 'greater than', less_than: 'less than', is: 'is' },
+    boolean: { yesTrue: 'Yes / True', noFalse: 'No / False' },
+    options: { transcode: 'Transcode', copy: 'Copy', directplay: 'Direct Play', movie: 'Movie', episode: 'Episode', track: 'Track', playing: 'Playing', paused: 'Paused', buffering: 'Buffering', cellular: 'Cellular' },
+    placeholders: { numberExample: 'e.g. 20', playerExample: 'e.g. Plex Web', ruleName: 'Rule name...' },
+    empty: { title: 'No rules configured', description: 'Add a rule below to start protecting your server automatically.' },
+    rule: { conditionCount: '{count} condition', conditionCount_plural: '{count} conditions', logic: 'Logic:' },
+    status: { active: 'Active', disabled: 'Disabled' },
+    logic: { and: 'AND', or: 'OR' },
+    match: { title: 'Match', followingConditions: 'of the following conditions' },
+    actions: { remove: 'Remove', delete: 'Delete', addCondition: 'Add Condition', addRule: 'Add New Rule', saveRules: 'Save Rules' },
+    editor: { killMessage: 'Kill Message', killMessageHint: "(shown on user's Plex client)", killMessagePlaceholder: 'Your stream has been stopped by the server administrator.' },
+    toasts: { loadFailed: 'Failed to load rules', saved: 'Stream rules saved!', saveFailed: 'Failed to save rules' },
+    defaults: { newRuleName: 'New Rule', killMessage: 'Your stream has been stopped by the server administrator.' },
+} } });
+
 Object.assign(en, { maintenance: {
     ...en.maintenance,
     page: { title: 'Cleaner', disabledTitle: 'Cleaner Disabled', disabledDescription: 'Experimental Cleaner Mode is currently OFF.', disabledHint: 'Enable it in `Settings` → `System` under `Maintenance Experimental Mode`, then click Save Settings.', controlCenter: 'Cleaner Control Center', controlCenterDescription: 'Dedicated module for library maintenance automation: rules, collections, candidates, execution timeline, calendar, storage, and governance.' },

--- a/client/discovery/i18n/es.ts
+++ b/client/discovery/i18n/es.ts
@@ -478,6 +478,25 @@ Object.assign(es, { homeDashboard: { ...es.homeDashboard, opsSnapshot: {
     empty: { noIncidents: 'Sin incidentes', unavailable: 'Resumen operativo no disponible.' },
 } } });
 
+Object.assign(es, { settings: { ...es.settings, streamKillRules: {
+    title: 'Reglas de detención de transmisiones',
+    description: { beforeInterval: 'Define reglas que finalizan automáticamente las transmisiones de Plex. Las reglas se evalúan cada ', interval: '15 segundos', afterInterval: '. Combina las condiciones con ', andAllMatch: ' (todas deben coincidir) u ', orAnyMatch: ' (cualquiera debe coincidir). ', afterLogic: 'El mensaje de detención aparece en el cliente Plex del usuario.' },
+    fields: { isTranscoding: 'Se está transcodificando', videoResolution: 'Resolución de vídeo', transcodeVideoDecision: 'Decisión de transcodificación', mediaType: 'Tipo de medio', state: 'Estado de reproducción', sessionLocation: 'Ubicación de conexión', videoCodec: 'Códec de vídeo', audioCodec: 'Códec de audio', bandwidth: 'Ancho de banda (Mbps)', user: 'Nombre de usuario', playerProduct: 'Aplicación de reproducción', playerTitle: 'Nombre del reproductor/dispositivo' },
+    operators: { equals: 'es igual a', not_equals: 'no es igual a', contains: 'contiene', not_contains: 'no contiene', greater_than: 'mayor que', less_than: 'menor que', is: 'es' },
+    boolean: { yesTrue: 'Sí / Verdadero', noFalse: 'No / Falso' },
+    options: { transcode: 'Transcodificar', copy: 'Copiar', directplay: 'Reproducción directa', movie: 'Película', episode: 'Episodio', track: 'Pista', playing: 'Reproduciendo', paused: 'En pausa', buffering: 'Almacenando en búfer', cellular: 'Datos móviles' },
+    placeholders: { numberExample: 'p. ej. 20', playerExample: 'p. ej. Plex Web', ruleName: 'Nombre de la regla...' },
+    empty: { title: 'No hay reglas configuradas', description: 'Añade una regla a continuación para empezar a proteger tu servidor automáticamente.' },
+    rule: { conditionCount: '{count} condición', conditionCount_plural: '{count} condiciones', logic: 'Lógica:' },
+    status: { active: 'Activa', disabled: 'Desactivada' },
+    logic: { and: 'Y', or: 'O' },
+    match: { title: 'Coincidir', followingConditions: 'de las siguientes condiciones' },
+    actions: { remove: 'Quitar', delete: 'Eliminar', addCondition: 'Añadir condición', addRule: 'Añadir nueva regla', saveRules: 'Guardar reglas' },
+    editor: { killMessage: 'Mensaje de detención', killMessageHint: '(se muestra en el cliente Plex del usuario)', killMessagePlaceholder: 'Tu transmisión ha sido detenida por el administrador del servidor.' },
+    toasts: { loadFailed: 'No se pudieron cargar las reglas', saved: '¡Reglas de transmisión guardadas!', saveFailed: 'No se pudieron guardar las reglas' },
+    defaults: { newRuleName: 'Nueva regla', killMessage: 'Tu transmisión ha sido detenida por el administrador del servidor.' },
+} } });
+
 Object.assign(es, { homeDashboard: { ...es.homeDashboard, nowPlayingCompanion: {
     ...es.homeDashboard.nowPlayingCompanion,
     timeline: { release: 'Estreno', runtime: 'Duración', episodeRuntime: 'Duración del episodio', genres: 'Géneros', tmdbScore: 'Puntuación de TMDB', status: 'Estado', currentEpisode: 'Episodio actual', episodeAirDate: 'Fecha de emisión del episodio' },

--- a/client/discovery/i18n/fr.ts
+++ b/client/discovery/i18n/fr.ts
@@ -1858,6 +1858,25 @@ Object.assign(fr, { homeDashboard: { ...fr.homeDashboard, opsSnapshot: {
     empty: { noIncidents: 'Aucun incident', unavailable: 'Aperçu des opérations indisponible.' },
 } } });
 
+Object.assign(fr, { settings: { ...fr.settings, streamKillRules: {
+    title: "Règles d'arrêt des flux",
+    description: { beforeInterval: 'Définissez des règles qui arrêtent automatiquement les flux Plex. Les règles sont évaluées toutes les ', interval: '15 secondes', afterInterval: '. Combinez les conditions avec ', andAllMatch: ' (toutes doivent correspondre) ou ', orAnyMatch: ' (au moins une doit correspondre). ', afterLogic: "Le message d'arrêt s'affiche sur le client Plex de l'utilisateur." },
+    fields: { isTranscoding: 'En cours de transcodage', videoResolution: 'Résolution vidéo', transcodeVideoDecision: 'Décision de transcodage', mediaType: 'Type de média', state: 'État de lecture', sessionLocation: 'Emplacement de connexion', videoCodec: 'Codec vidéo', audioCodec: 'Codec audio', bandwidth: 'Bande passante (Mbps)', user: "Nom d'utilisateur", playerProduct: 'Application de lecture', playerTitle: "Nom du lecteur/de l'appareil" },
+    operators: { equals: 'est égal à', not_equals: "n'est pas égal à", contains: 'contient', not_contains: 'ne contient pas', greater_than: 'supérieur à', less_than: 'inférieur à', is: 'est' },
+    boolean: { yesTrue: 'Oui / Vrai', noFalse: 'Non / Faux' },
+    options: { transcode: 'Transcoder', copy: 'Copier', directplay: 'Lecture directe', movie: 'Film', episode: 'Épisode', track: 'Piste', playing: 'En lecture', paused: 'En pause', buffering: 'Mise en mémoire tampon', cellular: 'Cellulaire' },
+    placeholders: { numberExample: 'ex. 20', playerExample: 'ex. Plex Web', ruleName: 'Nom de la règle...' },
+    empty: { title: 'Aucune règle configurée', description: 'Ajoutez une règle ci-dessous pour commencer à protéger votre serveur automatiquement.' },
+    rule: { conditionCount: '{count} condition', conditionCount_plural: '{count} conditions', logic: 'Logique :' },
+    status: { active: 'Active', disabled: 'Désactivée' },
+    logic: { and: 'ET', or: 'OU' },
+    match: { title: 'Faire correspondre', followingConditions: 'des conditions suivantes' },
+    actions: { remove: 'Retirer', delete: 'Supprimer', addCondition: 'Ajouter une condition', addRule: 'Ajouter une règle', saveRules: 'Enregistrer les règles' },
+    editor: { killMessage: "Message d'arrêt", killMessageHint: "(affiché sur le client Plex de l'utilisateur)", killMessagePlaceholder: 'Votre flux a été arrêté par l’administrateur du serveur.' },
+    toasts: { loadFailed: 'Impossible de charger les règles', saved: 'Règles de flux enregistrées !', saveFailed: 'Impossible d’enregistrer les règles' },
+    defaults: { newRuleName: 'Nouvelle règle', killMessage: 'Votre flux a été arrêté par l’administrateur du serveur.' },
+} } });
+
 Object.assign(fr, { homeDashboard: { ...fr.homeDashboard, nowPlayingCompanion: {
     ...fr.homeDashboard.nowPlayingCompanion,
     timeline: {

--- a/client/discovery/i18n/it.ts
+++ b/client/discovery/i18n/it.ts
@@ -60,6 +60,25 @@ Object.assign(it, { homeDashboard: { ...it.homeDashboard, opsSnapshot: {
     empty: { noIncidents: 'Nessun incidente', unavailable: 'Riepilogo operativo non disponibile.' },
 } } });
 
+Object.assign(it, { settings: { ...it.settings, streamKillRules: {
+    title: 'Regole di interruzione degli streaming',
+    description: { beforeInterval: 'Definisci regole che interrompono automaticamente gli streaming Plex. Le regole vengono valutate ogni ', interval: '15 secondi', afterInterval: '. Combina le condizioni con ', andAllMatch: ' (devono corrispondere tutte) oppure ', orAnyMatch: ' (deve corrisponderne almeno una). ', afterLogic: "Il messaggio di interruzione appare nel client Plex dell'utente." },
+    fields: { isTranscoding: 'In transcodifica', videoResolution: 'Risoluzione video', transcodeVideoDecision: 'Decisione di transcodifica', mediaType: 'Tipo di contenuto', state: 'Stato di riproduzione', sessionLocation: 'Posizione della connessione', videoCodec: 'Codec video', audioCodec: 'Codec audio', bandwidth: 'Larghezza di banda (Mbps)', user: 'Nome utente', playerProduct: 'App del player', playerTitle: 'Nome del player/dispositivo' },
+    operators: { equals: 'è uguale a', not_equals: 'non è uguale a', contains: 'contiene', not_contains: 'non contiene', greater_than: 'maggiore di', less_than: 'minore di', is: 'è' },
+    boolean: { yesTrue: 'Sì / Vero', noFalse: 'No / Falso' },
+    options: { transcode: 'Transcodifica', copy: 'Copia', directplay: 'Riproduzione diretta', movie: 'Film', episode: 'Episodio', track: 'Traccia', playing: 'In riproduzione', paused: 'In pausa', buffering: 'In buffering', cellular: 'Rete cellulare' },
+    placeholders: { numberExample: 'es. 20', playerExample: 'es. Plex Web', ruleName: 'Nome regola...' },
+    empty: { title: 'Nessuna regola configurata', description: 'Aggiungi una regola qui sotto per iniziare a proteggere automaticamente il tuo server.' },
+    rule: { conditionCount: '{count} condizione', conditionCount_plural: '{count} condizioni', logic: 'Logica:' },
+    status: { active: 'Attiva', disabled: 'Disattivata' },
+    logic: { and: 'E', or: 'O' },
+    match: { title: 'Corrispondenza', followingConditions: 'delle condizioni seguenti' },
+    actions: { remove: 'Rimuovi', delete: 'Elimina', addCondition: 'Aggiungi condizione', addRule: 'Aggiungi nuova regola', saveRules: 'Salva regole' },
+    editor: { killMessage: 'Messaggio di interruzione', killMessageHint: "(mostrato nel client Plex dell'utente)", killMessagePlaceholder: "Il tuo streaming è stato interrotto dall'amministratore del server." },
+    toasts: { loadFailed: 'Impossibile caricare le regole', saved: 'Regole di streaming salvate!', saveFailed: 'Impossibile salvare le regole' },
+    defaults: { newRuleName: 'Nuova regola', killMessage: "Il tuo streaming è stato interrotto dall'amministratore del server." },
+} } });
+
 Object.assign(it, { homeDashboard: { ...it.homeDashboard, nowPlayingCompanion: {
     ...it.homeDashboard.nowPlayingCompanion,
     timeline: { release: 'Uscita', runtime: 'Durata', episodeRuntime: 'Durata dell’episodio', genres: 'Generi', tmdbScore: 'Punteggio TMDB', status: 'Stato', currentEpisode: 'Episodio corrente', episodeAirDate: 'Data di trasmissione dell’episodio' },

--- a/client/discovery/i18n/ja.ts
+++ b/client/discovery/i18n/ja.ts
@@ -60,6 +60,25 @@ Object.assign(ja, { homeDashboard: { ...ja.homeDashboard, opsSnapshot: {
     empty: { noIncidents: 'インシデントはありません', unavailable: '運用スナップショットは利用できません。' },
 } } });
 
+Object.assign(ja, { settings: { ...ja.settings, streamKillRules: {
+    title: 'ストリーム停止ルール',
+    description: { beforeInterval: 'Plexストリームを自動停止するルールを定義します。ルールは', interval: '15秒', afterInterval: 'ごとに評価されます。条件は「', andAllMatch: '」（すべて一致）か、「', orAnyMatch: '」（いずれかが一致）で組み合わせます。', afterLogic: '停止メッセージはユーザーのPlexクライアント画面に表示されます。' },
+    fields: { isTranscoding: 'トランスコード中', videoResolution: '映像解像度', transcodeVideoDecision: '映像トランスコードの判定', mediaType: 'メディア種別', state: '再生状態', sessionLocation: '接続場所', videoCodec: '映像コーデック', audioCodec: '音声コーデック', bandwidth: '帯域幅 (Mbps)', user: 'ユーザー名', playerProduct: 'プレーヤーアプリ', playerTitle: 'プレーヤー/デバイス名' },
+    operators: { equals: '次と等しい', not_equals: '次と等しくない', contains: '次を含む', not_contains: '次を含まない', greater_than: '次より大きい', less_than: '次より小さい', is: '次である' },
+    boolean: { yesTrue: 'はい / 真', noFalse: 'いいえ / 偽' },
+    options: { transcode: 'トランスコード', copy: 'コピー', directplay: '直接再生', movie: '映画', episode: 'エピソード', track: 'トラック', playing: '再生中', paused: '一時停止中', buffering: 'バッファリング中', cellular: 'モバイル通信' },
+    placeholders: { numberExample: '例: 20', playerExample: '例: Plex Web', ruleName: 'ルール名...' },
+    empty: { title: '設定済みのルールはありません', description: '以下にルールを追加して、サーバーの自動保護を開始してください。' },
+    rule: { conditionCount: '{count} 件の条件', conditionCount_plural: '{count} 件の条件', logic: 'ロジック:' },
+    status: { active: '有効', disabled: '無効' },
+    logic: { and: 'かつ', or: 'または' },
+    match: { title: '一致', followingConditions: '以下の条件' },
+    actions: { remove: '削除', delete: '削除', addCondition: '条件を追加', addRule: '新しいルールを追加', saveRules: 'ルールを保存' },
+    editor: { killMessage: '停止メッセージ', killMessageHint: '(ユーザーのPlexクライアントに表示)', killMessagePlaceholder: 'ストリームはサーバー管理者によって停止されました。' },
+    toasts: { loadFailed: 'ルールを読み込めませんでした', saved: 'ストリームルールを保存しました。', saveFailed: 'ルールを保存できませんでした' },
+    defaults: { newRuleName: '新しいルール', killMessage: 'ストリームはサーバー管理者によって停止されました。' },
+} } });
+
 Object.assign(ja, { homeDashboard: { ...ja.homeDashboard, nowPlayingCompanion: {
     ...ja.homeDashboard.nowPlayingCompanion,
     timeline: { release: '公開日', runtime: '上映時間', episodeRuntime: 'エピソード時間', genres: 'ジャンル', tmdbScore: 'TMDBスコア', status: '状態', currentEpisode: '現在のエピソード', episodeAirDate: 'エピソードの放送日' },

--- a/client/discovery/i18n/nl.ts
+++ b/client/discovery/i18n/nl.ts
@@ -60,6 +60,25 @@ Object.assign(nl, { homeDashboard: { ...nl.homeDashboard, opsSnapshot: {
     empty: { noIncidents: 'Geen incidenten', unavailable: 'Operationeel overzicht niet beschikbaar.' },
 } } });
 
+Object.assign(nl, { settings: { ...nl.settings, streamKillRules: {
+    title: 'Regels voor het stoppen van streams',
+    description: { beforeInterval: 'Stel regels in die Plex-streams automatisch stoppen. Regels worden elke ', interval: '15 seconden', afterInterval: ' geëvalueerd. Combineer voorwaarden met ', andAllMatch: ' (ze moeten allemaal overeenkomen) of ', orAnyMatch: ' (er moet er minstens één overeenkomen). ', afterLogic: 'Het stopbericht verschijnt op het Plex-clientsscherm van de gebruiker.' },
+    fields: { isTranscoding: 'Wordt getranscodeerd', videoResolution: 'Videoresolutie', transcodeVideoDecision: 'Transcodebeslissing', mediaType: 'Mediatype', state: 'Afspeelstatus', sessionLocation: 'Verbindingslocatie', videoCodec: 'Videocodec', audioCodec: 'Audiocodec', bandwidth: 'Bandbreedte (Mbps)', user: 'Gebruikersnaam', playerProduct: 'Speler-app', playerTitle: 'Naam speler/apparaat' },
+    operators: { equals: 'is gelijk aan', not_equals: 'is niet gelijk aan', contains: 'bevat', not_contains: 'bevat niet', greater_than: 'groter dan', less_than: 'kleiner dan', is: 'is' },
+    boolean: { yesTrue: 'Ja / Waar', noFalse: 'Nee / Onwaar' },
+    options: { transcode: 'Transcoderen', copy: 'Kopiëren', directplay: 'Direct afspelen', movie: 'Film', episode: 'Aflevering', track: 'Track', playing: 'Wordt afgespeeld', paused: 'Gepauzeerd', buffering: 'Bufferen', cellular: 'Mobiel netwerk' },
+    placeholders: { numberExample: 'bijv. 20', playerExample: 'bijv. Plex Web', ruleName: 'Regelnaam...' },
+    empty: { title: 'Geen regels geconfigureerd', description: 'Voeg hieronder een regel toe om je server automatisch te beschermen.' },
+    rule: { conditionCount: '{count} voorwaarde', conditionCount_plural: '{count} voorwaarden', logic: 'Logica:' },
+    status: { active: 'Actief', disabled: 'Uitgeschakeld' },
+    logic: { and: 'EN', or: 'OF' },
+    match: { title: 'Overeenkomen', followingConditions: 'met de volgende voorwaarden' },
+    actions: { remove: 'Verwijderen', delete: 'Verwijderen', addCondition: 'Voorwaarde toevoegen', addRule: 'Nieuwe regel toevoegen', saveRules: 'Regels opslaan' },
+    editor: { killMessage: 'Stopbericht', killMessageHint: '(weergegeven in de Plex-client van de gebruiker)', killMessagePlaceholder: 'Je stream is gestopt door de serverbeheerder.' },
+    toasts: { loadFailed: 'Regels konden niet worden geladen', saved: 'Streamregels opgeslagen!', saveFailed: 'Regels konden niet worden opgeslagen' },
+    defaults: { newRuleName: 'Nieuwe regel', killMessage: 'Je stream is gestopt door de serverbeheerder.' },
+} } });
+
 Object.assign(nl, { homeDashboard: { ...nl.homeDashboard, nowPlayingCompanion: {
     ...nl.homeDashboard.nowPlayingCompanion,
     timeline: { release: 'Uitgave', runtime: 'Speelduur', episodeRuntime: 'Speelduur aflevering', genres: 'Genres', tmdbScore: 'TMDB-score', status: 'Status', currentEpisode: 'Huidige aflevering', episodeAirDate: 'Uitzenddatum aflevering' },

--- a/client/discovery/i18n/pl.ts
+++ b/client/discovery/i18n/pl.ts
@@ -60,6 +60,25 @@ Object.assign(pl, { homeDashboard: { ...pl.homeDashboard, opsSnapshot: {
     empty: { noIncidents: 'Brak incydentów', unavailable: 'Podsumowanie operacyjne jest niedostępne.' },
 } } });
 
+Object.assign(pl, { settings: { ...pl.settings, streamKillRules: {
+    title: 'Reguły przerywania strumieni',
+    description: { beforeInterval: 'Zdefiniuj reguły, które automatycznie przerywają strumienie Plex. Reguły są sprawdzane co ', interval: '15 sekund', afterInterval: '. Połącz warunki za pomocą ', andAllMatch: ' (wszystkie muszą pasować) lub ', orAnyMatch: ' (musi pasować dowolny). ', afterLogic: 'Komunikat o przerwaniu pojawi się na ekranie klienta Plex użytkownika.' },
+    fields: { isTranscoding: 'Trwa transkodowanie', videoResolution: 'Rozdzielczość wideo', transcodeVideoDecision: 'Decyzja transkodowania', mediaType: 'Typ multimediów', state: 'Stan odtwarzania', sessionLocation: 'Lokalizacja połączenia', videoCodec: 'Kodek wideo', audioCodec: 'Kodek audio', bandwidth: 'Przepustowość (Mbps)', user: 'Nazwa użytkownika', playerProduct: 'Aplikacja odtwarzacza', playerTitle: 'Nazwa odtwarzacza/urządzenia' },
+    operators: { equals: 'jest równe', not_equals: 'nie jest równe', contains: 'zawiera', not_contains: 'nie zawiera', greater_than: 'większe niż', less_than: 'mniejsze niż', is: 'jest' },
+    boolean: { yesTrue: 'Tak / Prawda', noFalse: 'Nie / Fałsz' },
+    options: { transcode: 'Transkodowanie', copy: 'Kopiowanie', directplay: 'Bezpośrednie odtwarzanie', movie: 'Film', episode: 'Odcinek', track: 'Utwór', playing: 'Odtwarzanie', paused: 'Wstrzymano', buffering: 'Buforowanie', cellular: 'Sieć komórkowa' },
+    placeholders: { numberExample: 'np. 20', playerExample: 'np. Plex Web', ruleName: 'Nazwa reguły...' },
+    empty: { title: 'Brak skonfigurowanych reguł', description: 'Dodaj regułę poniżej, aby automatycznie chronić swój serwer.' },
+    rule: { conditionCount: '{count} warunek', conditionCount_plural: 'Liczba warunków: {count}', logic: 'Logika:' },
+    status: { active: 'Aktywna', disabled: 'Wyłączona' },
+    logic: { and: 'I', or: 'LUB' },
+    match: { title: 'Dopasuj', followingConditions: 'do następujących warunków' },
+    actions: { remove: 'Usuń', delete: 'Usuń', addCondition: 'Dodaj warunek', addRule: 'Dodaj nową regułę', saveRules: 'Zapisz reguły' },
+    editor: { killMessage: 'Komunikat o przerwaniu', killMessageHint: '(wyświetlany w kliencie Plex użytkownika)', killMessagePlaceholder: 'Twój strumień został zatrzymany przez administratora serwera.' },
+    toasts: { loadFailed: 'Nie udało się wczytać reguł', saved: 'Reguły strumieni zapisane!', saveFailed: 'Nie udało się zapisać reguł' },
+    defaults: { newRuleName: 'Nowa reguła', killMessage: 'Twój strumień został zatrzymany przez administratora serwera.' },
+} } });
+
 Object.assign(pl, { homeDashboard: { ...pl.homeDashboard, nowPlayingCompanion: {
     ...pl.homeDashboard.nowPlayingCompanion,
     timeline: { release: 'Premiera', runtime: 'Czas trwania', episodeRuntime: 'Czas trwania odcinka', genres: 'Gatunki', tmdbScore: 'Ocena TMDB', status: 'Status', currentEpisode: 'Bieżący odcinek', episodeAirDate: 'Data emisji odcinka' },

--- a/client/discovery/i18n/pt-BR.ts
+++ b/client/discovery/i18n/pt-BR.ts
@@ -60,6 +60,25 @@ Object.assign(ptBR, { homeDashboard: { ...ptBR.homeDashboard, opsSnapshot: {
     empty: { noIncidents: 'Sem incidentes', unavailable: 'Resumo operacional indisponível.' },
 } } });
 
+Object.assign(ptBR, { settings: { ...ptBR.settings, streamKillRules: {
+    title: 'Regras de interrupção de streams',
+    description: { beforeInterval: 'Defina regras que encerram automaticamente streams do Plex. As regras são avaliadas a cada ', interval: '15 segundos', afterInterval: '. Combine as condições usando ', andAllMatch: ' (todas devem corresponder) ou ', orAnyMatch: ' (qualquer uma deve corresponder). ', afterLogic: 'A mensagem de interrupção aparece no cliente Plex do usuário.' },
+    fields: { isTranscoding: 'Está transcodificando', videoResolution: 'Resolução de vídeo', transcodeVideoDecision: 'Decisão de transcodificação', mediaType: 'Tipo de mídia', state: 'Estado de reprodução', sessionLocation: 'Local da conexão', videoCodec: 'Codec de vídeo', audioCodec: 'Codec de áudio', bandwidth: 'Largura de banda (Mbps)', user: 'Nome de usuário', playerProduct: 'Aplicativo do player', playerTitle: 'Nome do player/dispositivo' },
+    operators: { equals: 'é igual a', not_equals: 'não é igual a', contains: 'contém', not_contains: 'não contém', greater_than: 'maior que', less_than: 'menor que', is: 'é' },
+    boolean: { yesTrue: 'Sim / Verdadeiro', noFalse: 'Não / Falso' },
+    options: { transcode: 'Transcodificar', copy: 'Copiar', directplay: 'Reprodução direta', movie: 'Filme', episode: 'Episódio', track: 'Faixa', playing: 'Reproduzindo', paused: 'Pausado', buffering: 'Armazenando em buffer', cellular: 'Celular' },
+    placeholders: { numberExample: 'ex.: 20', playerExample: 'ex.: Plex Web', ruleName: 'Nome da regra...' },
+    empty: { title: 'Nenhuma regra configurada', description: 'Adicione uma regra abaixo para começar a proteger seu servidor automaticamente.' },
+    rule: { conditionCount: '{count} condição', conditionCount_plural: '{count} condições', logic: 'Lógica:' },
+    status: { active: 'Ativa', disabled: 'Desativada' },
+    logic: { and: 'E', or: 'OU' },
+    match: { title: 'Corresponder', followingConditions: 'das condições a seguir' },
+    actions: { remove: 'Remover', delete: 'Excluir', addCondition: 'Adicionar condição', addRule: 'Adicionar nova regra', saveRules: 'Salvar regras' },
+    editor: { killMessage: 'Mensagem de interrupção', killMessageHint: '(mostrada no cliente Plex do usuário)', killMessagePlaceholder: 'Seu stream foi interrompido pelo administrador do servidor.' },
+    toasts: { loadFailed: 'Não foi possível carregar as regras', saved: 'Regras de stream salvas!', saveFailed: 'Não foi possível salvar as regras' },
+    defaults: { newRuleName: 'Nova regra', killMessage: 'Seu stream foi interrompido pelo administrador do servidor.' },
+} } });
+
 Object.assign(ptBR, { homeDashboard: { ...ptBR.homeDashboard, nowPlayingCompanion: {
     ...ptBR.homeDashboard.nowPlayingCompanion,
     timeline: { release: 'Lançamento', runtime: 'Duração', episodeRuntime: 'Duração do episódio', genres: 'Gêneros', tmdbScore: 'Nota do TMDB', status: 'Status', currentEpisode: 'Episódio atual', episodeAirDate: 'Data de exibição do episódio' },

--- a/client/discovery/i18n/ru.ts
+++ b/client/discovery/i18n/ru.ts
@@ -60,6 +60,25 @@ Object.assign(ru, { homeDashboard: { ...ru.homeDashboard, opsSnapshot: {
     empty: { noIncidents: 'Нет инцидентов', unavailable: 'Оперативная сводка недоступна.' },
 } } });
 
+Object.assign(ru, { settings: { ...ru.settings, streamKillRules: {
+    title: 'Правила остановки потоков',
+    description: { beforeInterval: 'Настройте правила, которые автоматически останавливают потоки Plex. Правила проверяются каждые ', interval: '15 секунд', afterInterval: '. Объединяйте условия с помощью ', andAllMatch: ' (должны совпасть все) или ', orAnyMatch: ' (достаточно совпадения любого). ', afterLogic: 'Сообщение об остановке появится в клиенте Plex пользователя.' },
+    fields: { isTranscoding: 'Выполняется транскодирование', videoResolution: 'Разрешение видео', transcodeVideoDecision: 'Решение о транскодировании', mediaType: 'Тип медиа', state: 'Состояние воспроизведения', sessionLocation: 'Расположение подключения', videoCodec: 'Видеокодек', audioCodec: 'Аудиокодек', bandwidth: 'Пропускная способность (Mbps)', user: 'Имя пользователя', playerProduct: 'Приложение проигрывателя', playerTitle: 'Имя проигрывателя/устройства' },
+    operators: { equals: 'равно', not_equals: 'не равно', contains: 'содержит', not_contains: 'не содержит', greater_than: 'больше', less_than: 'меньше', is: 'является' },
+    boolean: { yesTrue: 'Да / Истина', noFalse: 'Нет / Ложь' },
+    options: { transcode: 'Транскодирование', copy: 'Копирование', directplay: 'Прямое воспроизведение', movie: 'Фильм', episode: 'Эпизод', track: 'Трек', playing: 'Воспроизводится', paused: 'Приостановлено', buffering: 'Буферизация', cellular: 'Мобильная сеть' },
+    placeholders: { numberExample: 'например, 20', playerExample: 'например, Plex Web', ruleName: 'Название правила...' },
+    empty: { title: 'Правила не настроены', description: 'Добавьте правило ниже, чтобы автоматически защищать сервер.' },
+    rule: { conditionCount: '{count} условие', conditionCount_plural: 'Количество условий: {count}', logic: 'Логика:' },
+    status: { active: 'Активно', disabled: 'Отключено' },
+    logic: { and: 'И', or: 'ИЛИ' },
+    match: { title: 'Сопоставить', followingConditions: 'со следующими условиями' },
+    actions: { remove: 'Удалить', delete: 'Удалить', addCondition: 'Добавить условие', addRule: 'Добавить новое правило', saveRules: 'Сохранить правила' },
+    editor: { killMessage: 'Сообщение об остановке', killMessageHint: '(отображается в клиенте Plex пользователя)', killMessagePlaceholder: 'Ваш поток остановлен администратором сервера.' },
+    toasts: { loadFailed: 'Не удалось загрузить правила', saved: 'Правила потоков сохранены!', saveFailed: 'Не удалось сохранить правила' },
+    defaults: { newRuleName: 'Новое правило', killMessage: 'Ваш поток остановлен администратором сервера.' },
+} } });
+
 Object.assign(ru, { homeDashboard: { ...ru.homeDashboard, nowPlayingCompanion: {
     ...ru.homeDashboard.nowPlayingCompanion,
     timeline: { release: 'Премьера', runtime: 'Длительность', episodeRuntime: 'Длительность эпизода', genres: 'Жанры', tmdbScore: 'Оценка TMDB', status: 'Статус', currentEpisode: 'Текущий эпизод', episodeAirDate: 'Дата выхода эпизода' },

--- a/client/settings/StreamKillRulesPanel.tsx
+++ b/client/settings/StreamKillRulesPanel.tsx
@@ -5,29 +5,68 @@ import { appConfirm } from '../shared/confirm';
 import { CustomSelect } from '../shared/ui';
 import { Loader, ToastContainer, pushToast, type ToastMessage } from '../shared/toast';
 import { SettingHint } from './SettingHint';
+import { useDiscoverI18n } from '../discovery/i18n';
 import type { User, AuditEntry, DeletedUser } from '../shared/types';
 import { formatDateTime, formatEventName, hexToRgb, getDaysUntilExpiry, addMonths, addYears, formatDate } from '../shared/format';
 // ─────────────────────────────────────────────────────────────────────────────
 // Stream Kill Rules Panel
 // ─────────────────────────────────────────────────────────────────────────────
 const RULE_FIELDS = [
-    { value: 'isTranscoding', label: 'Is Transcoding', type: 'bool' as const },
-    { value: 'videoResolution', label: 'Video Resolution', type: 'select' as const, options: ['4k', '1080', '720', '480', 'sd'] },
-    { value: 'transcodeVideoDecision', label: 'Transcode Decision', type: 'select' as const, options: ['transcode', 'copy', 'directplay'] },
-    { value: 'mediaType', label: 'Media Type', type: 'select' as const, options: ['movie', 'episode', 'track'] },
-    { value: 'state', label: 'Playback State', type: 'select' as const, options: ['playing', 'paused', 'buffering'] },
-    { value: 'sessionLocation', label: 'Connection Location', type: 'select' as const, options: ['lan', 'wan', 'cellular'] },
-    { value: 'videoCodec', label: 'Video Codec', type: 'text' as const },
-    { value: 'audioCodec', label: 'Audio Codec', type: 'text' as const },
-    { value: 'bandwidth', label: 'Bandwidth (Mbps)', type: 'number' as const },
-    { value: 'user', label: 'Username', type: 'text' as const },
-    { value: 'playerProduct', label: 'Player App', type: 'text' as const },
-    { value: 'playerTitle', label: 'Player/Device Name', type: 'text' as const },
+    { value: 'isTranscoding', type: 'bool' as const },
+    { value: 'videoResolution', type: 'select' as const, options: ['4k', '1080', '720', '480', 'sd'] },
+    { value: 'transcodeVideoDecision', type: 'select' as const, options: ['transcode', 'copy', 'directplay'] },
+    { value: 'mediaType', type: 'select' as const, options: ['movie', 'episode', 'track'] },
+    { value: 'state', type: 'select' as const, options: ['playing', 'paused', 'buffering'] },
+    { value: 'sessionLocation', type: 'select' as const, options: ['lan', 'wan', 'cellular'] },
+    { value: 'videoCodec', type: 'text' as const },
+    { value: 'audioCodec', type: 'text' as const },
+    { value: 'bandwidth', type: 'number' as const },
+    { value: 'user', type: 'text' as const },
+    { value: 'playerProduct', type: 'text' as const },
+    { value: 'playerTitle', type: 'text' as const },
 ];
-const KR_OP_TEXT = [{ value: 'equals', label: 'equals' }, { value: 'not_equals', label: 'not equals' }, { value: 'contains', label: 'contains' }, { value: 'not_contains', label: "doesn't contain" }];
-const KR_OP_NUMBER = [{ value: 'equals', label: 'equals' }, { value: 'not_equals', label: 'not equals' }, { value: 'greater_than', label: 'greater than' }, { value: 'less_than', label: 'less than' }];
-const KR_OP_BOOL = [{ value: 'equals', label: 'is' }];
-const KR_OP_SELECT = [{ value: 'equals', label: 'equals' }, { value: 'not_equals', label: 'not equals' }];
+const KR_OP_TEXT = [{ value: 'equals' }, { value: 'not_equals' }, { value: 'contains' }, { value: 'not_contains' }];
+const KR_OP_NUMBER = [{ value: 'equals' }, { value: 'not_equals' }, { value: 'greater_than' }, { value: 'less_than' }];
+const KR_OP_BOOL = [{ value: 'equals', labelKey: 'settings.streamKillRules.operators.is' }];
+const KR_OP_SELECT = [{ value: 'equals' }, { value: 'not_equals' }];
+const KR_FIELD_LABEL_KEYS: Record<string, string> = {
+    isTranscoding: 'settings.streamKillRules.fields.isTranscoding',
+    videoResolution: 'settings.streamKillRules.fields.videoResolution',
+    transcodeVideoDecision: 'settings.streamKillRules.fields.transcodeVideoDecision',
+    mediaType: 'settings.streamKillRules.fields.mediaType',
+    state: 'settings.streamKillRules.fields.state',
+    sessionLocation: 'settings.streamKillRules.fields.sessionLocation',
+    videoCodec: 'settings.streamKillRules.fields.videoCodec',
+    audioCodec: 'settings.streamKillRules.fields.audioCodec',
+    bandwidth: 'settings.streamKillRules.fields.bandwidth',
+    user: 'settings.streamKillRules.fields.user',
+    playerProduct: 'settings.streamKillRules.fields.playerProduct',
+    playerTitle: 'settings.streamKillRules.fields.playerTitle',
+};
+const KR_OPERATOR_LABEL_KEYS: Record<string, string> = {
+    equals: 'settings.streamKillRules.operators.equals',
+    not_equals: 'settings.streamKillRules.operators.not_equals',
+    contains: 'settings.streamKillRules.operators.contains',
+    not_contains: 'settings.streamKillRules.operators.not_contains',
+    greater_than: 'settings.streamKillRules.operators.greater_than',
+    less_than: 'settings.streamKillRules.operators.less_than',
+};
+const KR_OPTION_LABEL_KEYS: Record<string, string> = {
+    transcode: 'settings.streamKillRules.options.transcode',
+    copy: 'settings.streamKillRules.options.copy',
+    directplay: 'settings.streamKillRules.options.directplay',
+    movie: 'settings.streamKillRules.options.movie',
+    episode: 'settings.streamKillRules.options.episode',
+    track: 'settings.streamKillRules.options.track',
+    playing: 'settings.streamKillRules.options.playing',
+    paused: 'settings.streamKillRules.options.paused',
+    buffering: 'settings.streamKillRules.options.buffering',
+    cellular: 'settings.streamKillRules.options.cellular',
+};
+const KR_LOGIC_LABEL_KEYS: Record<string, string> = {
+    AND: 'settings.streamKillRules.logic.and',
+    OR: 'settings.streamKillRules.logic.or',
+};
 function krGetOps(field: any) {
     if (!field) return KR_OP_TEXT;
     if (field.type === 'bool') return KR_OP_BOOL;
@@ -36,9 +75,10 @@ function krGetOps(field: any) {
     return KR_OP_TEXT;
 }
 function krMkCond() { return { id: (typeof crypto !== 'undefined' && (crypto as any).randomUUID ? (crypto as any).randomUUID() : Math.random().toString(36).slice(2)), field: 'isTranscoding', operator: 'equals', value: 'true' }; }
-function krMkRule(): any { return { id: Date.now().toString(), name: 'New Rule', enabled: true, conditionLogic: 'AND', conditions: [krMkCond()], killMessage: 'Your stream has been stopped by the server administrator.' }; }
+function krMkRule(name: string, killMessage: string): any { return { id: Date.now().toString(), name, enabled: true, conditionLogic: 'AND', conditions: [krMkCond()], killMessage }; }
 
 const KRConditionRow: React.FC<{ cond: any; onCh: (c: any) => void; onDel: () => void }> = ({ cond, onCh, onDel }) => {
+    const { t } = useDiscoverI18n();
     const fd = RULE_FIELDS.find(f => f.value === cond.field);
     const ops = krGetOps(fd);
     const onField = (v: string) => {
@@ -46,11 +86,11 @@ const KRConditionRow: React.FC<{ cond: any; onCh: (c: any) => void; onDel: () =>
         const dv = def?.type === 'bool' ? 'true' : (def && 'options' in def && def.options ? def.options[0] : '');
         onCh({ ...cond, field: v, value: dv, operator: krGetOps(def)[0].value });
     };
-    const fieldOptions = RULE_FIELDS.map(f => ({ label: f.label, value: f.value }));
-    const opOptions = ops.map(o => ({ label: o.label, value: o.value }));
-    const boolOptions = [{ label: 'Yes / True', value: 'true' }, { label: 'No / False', value: 'false' }];
+    const fieldOptions = RULE_FIELDS.map(f => ({ label: t(KR_FIELD_LABEL_KEYS[f.value]), value: f.value }));
+    const opOptions = ops.map(o => ({ label: t('labelKey' in o ? o.labelKey : KR_OPERATOR_LABEL_KEYS[o.value]), value: o.value }));
+    const boolOptions = [{ label: t('settings.streamKillRules.boolean.yesTrue'), value: 'true' }, { label: t('settings.streamKillRules.boolean.noFalse'), value: 'false' }];
     const selectOptions = ('options' in (fd ?? {}) && (fd as any).options)
-        ? (fd as any).options.map((o: string) => ({ label: o, value: o }))
+        ? (fd as any).options.map((o: string) => ({ label: KR_OPTION_LABEL_KEYS[o] ? t(KR_OPTION_LABEL_KEYS[o]) : o.toUpperCase(), value: o }))
         : [];
 
     return (
@@ -84,10 +124,10 @@ const KRConditionRow: React.FC<{ cond: any; onCh: (c: any) => void; onDel: () =>
             ) : (
                 <input type={fd?.type === 'number' ? 'number' : 'text'} value={cond.value}
                     onChange={e => onCh({ ...cond, value: e.target.value })}
-                    placeholder={fd?.type === 'number' ? 'e.g. 20' : 'e.g. Plex Web'}
+                    placeholder={fd?.type === 'number' ? t('settings.streamKillRules.placeholders.numberExample') : t('settings.streamKillRules.placeholders.playerExample')}
                     className="flex-1 min-w-[100px] bg-background border border-border text-text rounded-lg px-3 py-2 text-sm focus:border-plex focus:ring-1 focus:ring-plex outline-none transition-all" />
             )}
-            <button onClick={onDel} title="Remove" className="p-1.5 text-red-400 hover:text-red-300 hover:bg-red-500/10 rounded-lg transition-all flex-shrink-0">
+            <button onClick={onDel} title={t('settings.streamKillRules.actions.remove')} className="p-1.5 text-red-400 hover:text-red-300 hover:bg-red-500/10 rounded-lg transition-all flex-shrink-0">
                 <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
             </button>
         </div>
@@ -96,6 +136,9 @@ const KRConditionRow: React.FC<{ cond: any; onCh: (c: any) => void; onDel: () =>
 
 
 export const StreamKillRulesPanel: React.FC<{ addToast: (m: string, t?: 'success' | 'error') => void; registerSaveHandler?: (handler: (() => Promise<boolean>) | null) => void }> = ({ addToast, registerSaveHandler }) => {
+    const { t } = useDiscoverI18n();
+    const tRef = useRef(t);
+    tRef.current = t;
     const [rules, setRules] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
@@ -103,7 +146,7 @@ export const StreamKillRulesPanel: React.FC<{ addToast: (m: string, t?: 'success
 
     useEffect(() => {
         apiFetch('/api/kill-rules').then(d => setRules(Array.isArray(d) ? d : []))
-            .catch(() => addToast('Failed to load rules', 'error'))
+            .catch(() => addToast(tRef.current('settings.streamKillRules.toasts.loadFailed'), 'error'))
             .finally(() => setLoading(false));
     }, []);
 
@@ -111,14 +154,14 @@ export const StreamKillRulesPanel: React.FC<{ addToast: (m: string, t?: 'success
         setSaving(true);
         try {
             await apiFetch('/api/kill-rules', { method: 'POST', body: JSON.stringify(r) });
-            addToast('Stream rules saved!');
+            addToast(tRef.current('settings.streamKillRules.toasts.saved'));
             return true;
         } catch {
-            addToast('Failed to save rules', 'error');
+            addToast(tRef.current('settings.streamKillRules.toasts.saveFailed'), 'error');
             return false;
         } finally { setSaving(false); }
     };
-    const addRule = () => { const r = krMkRule(); const u = [...rules, r]; setRules(u); setExpanded(r.id); };
+    const addRule = () => { const r = krMkRule(t('settings.streamKillRules.defaults.newRuleName'), t('settings.streamKillRules.defaults.killMessage')); const u = [...rules, r]; setRules(u); setExpanded(r.id); };
     const upd = (id: string, p: any) => setRules(prev => prev.map(r => r.id === id ? { ...r, ...p } : r));
     const del = (id: string) => setRules(prev => prev.filter(r => r.id !== id));
     const addCond = (id: string) => setRules(prev => prev.map(r => r.id === id ? { ...r, conditions: [...(r.conditions ?? []), krMkCond()] } : r));
@@ -137,16 +180,16 @@ export const StreamKillRulesPanel: React.FC<{ addToast: (m: string, t?: 'success
         <div className="mb-8 animate-fade-in">
             <h3 className="text-xl font-bold text-plex mb-1 border-b border-border pb-2 flex items-center gap-2">
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" /></svg>
-                Stream Kill Rules
+                {t('settings.streamKillRules.title')}
             </h3>
             <p className="text-sm text-muted mb-6 leading-relaxed">
-                Define rules that automatically terminate Plex streams. Rules are evaluated every <strong className="text-text">15 seconds</strong>. Combine conditions using <strong className="text-plex">AND</strong> (all must match) or <strong className="text-plex">OR</strong> (any must match). The kill message appears on the user's Plex client screen.
+                {t('settings.streamKillRules.description.beforeInterval')}<strong className="text-text">{t('settings.streamKillRules.description.interval')}</strong>{t('settings.streamKillRules.description.afterInterval')}<strong className="text-plex">{t('settings.streamKillRules.logic.and')}</strong>{t('settings.streamKillRules.description.andAllMatch')}<strong className="text-plex">{t('settings.streamKillRules.logic.or')}</strong>{t('settings.streamKillRules.description.orAnyMatch')}{t('settings.streamKillRules.description.afterLogic')}
             </p>
             {rules.length === 0 && (
                 <div className="flex flex-col items-center justify-center py-16 border-2 border-dashed border-border rounded-xl text-center gap-3 mb-6">
                     <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-muted opacity-40"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" /></svg>
-                    <p className="text-muted font-medium">No rules configured</p>
-                    <p className="text-muted text-sm">Add a rule below to start protecting your server automatically.</p>
+                    <p className="text-muted font-medium">{t('settings.streamKillRules.empty.title')}</p>
+                    <p className="text-muted text-sm">{t('settings.streamKillRules.empty.description')}</p>
                 </div>
             )}
             <div className="flex flex-col gap-4">
@@ -161,13 +204,13 @@ export const StreamKillRulesPanel: React.FC<{ addToast: (m: string, t?: 'success
                                 </button>
                                 <div className="flex-1 min-w-0">
                                     <input value={rule.name} onChange={e => { e.stopPropagation(); upd(rule.id, { name: e.target.value }); }} onClick={e => e.stopPropagation()}
-                                        className="bg-transparent border-none outline-none text-text font-bold text-sm w-full placeholder-muted/50" placeholder="Rule name..." />
+                                        className="bg-transparent border-none outline-none text-text font-bold text-sm w-full placeholder-muted/50" placeholder={t('settings.streamKillRules.placeholders.ruleName')} />
                                     <p className="text-muted text-xs mt-0.5">
-                                        {rule.conditions?.length || 0} condition{rule.conditions?.length !== 1 ? 's' : ''} · Logic: <span className="text-plex font-bold">{rule.conditionLogic}</span> · <span className={rule.enabled ? 'text-green-400 font-bold' : 'text-muted'}>{rule.enabled ? 'Active' : 'Disabled'}</span>
+                                        {t('settings.streamKillRules.rule.conditionCount', { count: rule.conditions?.length || 0 })} · {t('settings.streamKillRules.rule.logic')} <span className="text-plex font-bold">{KR_LOGIC_LABEL_KEYS[rule.conditionLogic] ? t(KR_LOGIC_LABEL_KEYS[rule.conditionLogic]) : rule.conditionLogic}</span> · <span className={rule.enabled ? 'text-green-400 font-bold' : 'text-muted'}>{rule.enabled ? t('settings.streamKillRules.status.active') : t('settings.streamKillRules.status.disabled')}</span>
                                     </p>
                                 </div>
                                 <div className="flex items-center gap-1 flex-shrink-0">
-                                    <button onClick={e => { e.stopPropagation(); del(rule.id); }} title="Delete" className="p-2 text-red-400 hover:text-red-300 hover:bg-red-500/10 rounded-lg transition-all">
+                                    <button onClick={e => { e.stopPropagation(); del(rule.id); }} title={t('settings.streamKillRules.actions.delete')} className="p-2 text-red-400 hover:text-red-300 hover:bg-red-500/10 rounded-lg transition-all">
                                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M3 6h18M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /></svg>
                                     </button>
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className={`text-muted transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}><path d="m6 9 6 6 6-6" /></svg>
@@ -176,14 +219,14 @@ export const StreamKillRulesPanel: React.FC<{ addToast: (m: string, t?: 'success
                             {isOpen && (
                                 <div className="pt-4 flex flex-col gap-5">
                                     <div className="flex items-center gap-3 flex-wrap">
-                                        <span className="text-muted text-xs font-bold uppercase tracking-wider">Match</span>
+                                        <span className="text-muted text-xs font-bold uppercase tracking-wider">{t('settings.streamKillRules.match.title')}</span>
                                         <div className="flex bg-black/40 rounded-lg p-0.5 border border-white/5">
                                             {(['AND', 'OR'] as const).map(l => (
                                                 <button key={l} onClick={() => upd(rule.id, { conditionLogic: l })}
-                                                    className={`px-4 py-1.5 rounded-md text-xs font-black uppercase tracking-wider transition-all ${rule.conditionLogic === l ? 'bg-plex text-black shadow' : 'text-muted hover:text-text'}`}>{l}</button>
+                                                    className={`px-4 py-1.5 rounded-md text-xs font-black uppercase tracking-wider transition-all ${rule.conditionLogic === l ? 'bg-plex text-black shadow' : 'text-muted hover:text-text'}`}>{t(KR_LOGIC_LABEL_KEYS[l])}</button>
                                             ))}
                                         </div>
-                                        <span className="text-muted text-xs font-bold uppercase tracking-wider">of the following conditions</span>
+                                        <span className="text-muted text-xs font-bold uppercase tracking-wider">{t('settings.streamKillRules.match.followingConditions')}</span>
                                     </div>
                                     <div className="flex flex-col gap-2">
                                         {(rule.conditions || []).map((c: any, i: number) => (
@@ -191,14 +234,14 @@ export const StreamKillRulesPanel: React.FC<{ addToast: (m: string, t?: 'success
                                         ))}
                                         <button onClick={() => addCond(rule.id)} className="flex items-center gap-2 text-plex text-sm font-bold hover:text-plex/80 transition-colors mt-1 w-fit py-1">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M12 5v14M5 12h14" /></svg>
-                                            Add Condition
+                                            {t('settings.streamKillRules.actions.addCondition')}
                                         </button>
                                     </div>
                                     <div>
-                                        <label className="text-xs font-bold uppercase tracking-wider text-muted mb-2 block">Kill Message <span className="normal-case font-normal text-white/30">(shown on user's Plex client)</span></label>
+                                        <label className="text-xs font-bold uppercase tracking-wider text-muted mb-2 block">{t('settings.streamKillRules.editor.killMessage')} <span className="normal-case font-normal text-white/30">{t('settings.streamKillRules.editor.killMessageHint')}</span></label>
                                         <textarea value={rule.killMessage} onChange={e => upd(rule.id, { killMessage: e.target.value })} rows={2}
                                             className="w-full bg-background border border-border text-text rounded-lg px-3 py-2 text-sm focus:border-plex focus:ring-1 focus:ring-plex outline-none transition-all resize-none"
-                                            placeholder="Your stream has been stopped by the server administrator." />
+                                            placeholder={t('settings.streamKillRules.editor.killMessagePlaceholder')} />
                                     </div>
                                 </div>
                             )}
@@ -209,11 +252,11 @@ export const StreamKillRulesPanel: React.FC<{ addToast: (m: string, t?: 'success
             <div className="flex items-center gap-3 mt-6 pt-4 border-t border-border">
                 <button onClick={addRule} className="flex items-center gap-2 px-3 py-2 bg-border text-text rounded-lg font-bold text-xs hover:bg-opacity-80 transition-all">
                     <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M12 5v14M5 12h14" /></svg>
-                    Add New Rule
+                    {t('settings.streamKillRules.actions.addRule')}
                 </button>
                 <button onClick={() => saveRules(rules)} disabled={saving} className="flex items-center gap-2 px-4 py-2 bg-plex text-background rounded-lg font-bold text-xs hover:opacity-90 transition-all disabled:opacity-50">
                     {saving ? <span className="w-4 h-4 border-2 border-background/50 border-t-transparent rounded-full animate-spin" /> : <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" /><polyline points="17 21 17 13 7 13 7 21" /><polyline points="7 3 7 8 15 8" /></svg>}
-                    Save Rules
+                    {t('settings.streamKillRules.actions.saveRules')}
                 </button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- localize the Stream Kill Rules settings panel
- add 65 explicit Stream Kill Rules translation keys across all 10 supported locales
- localize field, operator, status, editor, empty-state, toast, and enum display labels
- preserve all persisted rule fields, operators, condition values, and AND/OR logic
- localize default rule name and kill message only when creating new rules
- keep locale changes isolated from rule fetching, saving, and existing persisted rule content

## Validation
- `npm test`: 58/58 passed
- `npm run build:js`: passed
- `npm run build`: passed
- `git diff --check`: passed
- source/catalog parity: 65/65 keys across en, fr, de, es, pt-BR, it, ja, pl, nl, ru
- placeholder parity: passed across all 10 locales
- final translation sanity audit: passed

Known unrelated Poster Sets duplicate-object-key warnings remain unchanged.