### PR TITLE
i18n: add notification repeat-control translations

### DIFF
--- a/client/discovery/i18n/de.ts
+++ b/client/discovery/i18n/de.ts
@@ -1001,3 +1001,4 @@ Object.assign(de, { homeDashboard: { ...de.homeDashboard, nowPlayingCompanion: {
     header: { ...de.homeDashboard.nowPlayingCompanion.header, playbackProgress: '{type} · {progress}% angesehen' },
     summary: { progress: 'Fortschritt {progress}%', throughSession: '{progress}% dieser Sitzung' },
 } } });
+Object.assign(de, { notifications: { ...de.notifications, repeat: { expand: 'Zeige {count} Aktualisierungen', expand_plural: 'Zeige {count} Aktualisierungen', collapse: 'Wiederholte Aktualisierungen ausblenden', legacyHint: 'Es wird die neueste von {count} ähnlichen Benachrichtigungen angezeigt.' } } });

--- a/client/discovery/i18n/es.ts
+++ b/client/discovery/i18n/es.ts
@@ -997,3 +997,4 @@ Object.assign(es, { homeDashboard: { ...es.homeDashboard, nowPlayingCompanion: {
     header: { ...es.homeDashboard.nowPlayingCompanion.header, playbackProgress: '{type} · {progress}% visto' },
     summary: { progress: 'progreso {progress}%', throughSession: '{progress}% de esta sesión' },
 } } });
+Object.assign(es, { notifications: { ...es.notifications, repeat: { expand: 'Mostrar {count} actualizaciones', expand_plural: 'Mostrar {count} actualizaciones', collapse: 'Ocultar actualizaciones repetidas', legacyHint: 'Se muestra la más reciente de {count} alertas similares.' } } });

--- a/client/discovery/i18n/fr.ts
+++ b/client/discovery/i18n/fr.ts
@@ -2383,3 +2383,4 @@ Object.assign(fr, { homeDashboard: { ...fr.homeDashboard, nowPlayingCompanion: {
     header: { ...fr.homeDashboard.nowPlayingCompanion.header, playbackProgress: '{type} · {progress} % visionné' },
     summary: { progress: 'progression {progress} %', throughSession: '{progress} % de cette session' },
 } } });
+Object.assign(fr, { notifications: { ...fr.notifications, repeat: { expand: 'Afficher {count} mises à jour', expand_plural: 'Afficher {count} mises à jour', collapse: 'Masquer les mises à jour répétées', legacyHint: 'Affichage de la plus récente parmi {count} alertes similaires.' } } });

--- a/client/discovery/i18n/it.ts
+++ b/client/discovery/i18n/it.ts
@@ -602,3 +602,4 @@ Object.assign(it, { homeDashboard: { ...it.homeDashboard, nowPlayingCompanion: {
     header: { ...it.homeDashboard.nowPlayingCompanion.header, playbackProgress: '{type} · {progress}% visto' },
     summary: { progress: 'avanzamento {progress}%', throughSession: '{progress}% di questa sessione' },
 } } });
+Object.assign(it, { notifications: { ...it.notifications, repeat: { expand: 'Mostra {count} aggiornamenti', expand_plural: 'Mostra {count} aggiornamenti', collapse: 'Nascondi aggiornamenti ripetuti', legacyHint: 'Viene mostrato il più recente di {count} avvisi simili.' } } });

--- a/client/discovery/i18n/ja.ts
+++ b/client/discovery/i18n/ja.ts
@@ -601,3 +601,4 @@ Object.assign(ja, { homeDashboard: { ...ja.homeDashboard, nowPlayingCompanion: {
     header: { ...ja.homeDashboard.nowPlayingCompanion.header, playbackProgress: '{type}・{progress}% 視聴済み' },
     summary: { progress: '進行状況 {progress}%', throughSession: 'このセッションで {progress}% 視聴済み' },
 } } });
+Object.assign(ja, { notifications: { ...ja.notifications, repeat: { expand: '{count} 件の更新を表示', expand_plural: '{count} 件の更新を表示', collapse: '繰り返された更新を非表示', legacyHint: '{count} 件の類似アラートのうち最新のものを表示しています。' } } });

--- a/client/discovery/i18n/nl.ts
+++ b/client/discovery/i18n/nl.ts
@@ -601,3 +601,4 @@ Object.assign(nl, { homeDashboard: { ...nl.homeDashboard, nowPlayingCompanion: {
     header: { ...nl.homeDashboard.nowPlayingCompanion.header, playbackProgress: '{type} · {progress}% bekeken' },
     summary: { progress: 'voortgang {progress}%', throughSession: '{progress}% van deze sessie bekeken' },
 } } });
+Object.assign(nl, { notifications: { ...nl.notifications, repeat: { expand: 'Toon {count} updates', expand_plural: 'Toon {count} updates', collapse: 'Herhaalde updates verbergen', legacyHint: 'De nieuwste van {count} vergelijkbare meldingen wordt getoond.' } } });

--- a/client/discovery/i18n/pl.ts
+++ b/client/discovery/i18n/pl.ts
@@ -601,3 +601,4 @@ Object.assign(pl, { homeDashboard: { ...pl.homeDashboard, nowPlayingCompanion: {
     header: { ...pl.homeDashboard.nowPlayingCompanion.header, playbackProgress: '{type} · obejrzano {progress}%' },
     summary: { progress: 'postęp {progress}%', throughSession: 'Obejrzano {progress}% tej sesji' },
 } } });
+Object.assign(pl, { notifications: { ...pl.notifications, repeat: { expand: 'Pokaż {count} aktualizacji', expand_plural: 'Pokaż {count} aktualizacji', collapse: 'Ukryj powtarzające się aktualizacje', legacyHint: 'Wyświetlana jest najnowsza z {count} podobnych alertów.' } } });

--- a/client/discovery/i18n/pt-BR.ts
+++ b/client/discovery/i18n/pt-BR.ts
@@ -602,3 +602,4 @@ Object.assign(ptBR, { homeDashboard: { ...ptBR.homeDashboard, nowPlayingCompanio
     header: { ...ptBR.homeDashboard.nowPlayingCompanion.header, playbackProgress: '{type} · {progress}% assistido' },
     summary: { progress: 'progresso {progress}%', throughSession: '{progress}% desta sessão' },
 } } });
+Object.assign(ptBR, { notifications: { ...ptBR.notifications, repeat: { expand: 'Mostrar {count} atualizações', expand_plural: 'Mostrar {count} atualizações', collapse: 'Ocultar atualizações repetidas', legacyHint: 'Mostrando a mais recente de {count} alertas semelhantes.' } } });

--- a/client/discovery/i18n/ru.ts
+++ b/client/discovery/i18n/ru.ts
@@ -601,3 +601,4 @@ Object.assign(ru, { homeDashboard: { ...ru.homeDashboard, nowPlayingCompanion: {
     header: { ...ru.homeDashboard.nowPlayingCompanion.header, playbackProgress: '{type} · просмотрено {progress}%' },
     summary: { progress: 'прогресс: {progress}%', throughSession: 'Просмотрено {progress}% этой сессии' },
 } } });
+Object.assign(ru, { notifications: { ...ru.notifications, repeat: { expand: 'Показать {count} обновлений', expand_plural: 'Показать {count} обновлений', collapse: 'Скрыть повторяющиеся обновления', legacyHint: 'Показано последнее из {count} похожих уведомлений.' } } });


### PR DESCRIPTION
## Summary

Adds complete secondary-locale translations for the repeated in-app notification controls.

This completes explicit parity for:

`notifications.repeat`

Supported secondary locales:

- French (`fr`)
- German (`de`)
- Spanish (`es`)
- Brazilian Portuguese (`pt-BR`)
- Italian (`it`)
- Japanese (`ja`)
- Polish (`pl`)
- Dutch (`nl`)
- Russian (`ru`)

## Coverage

The canonical English namespace contains 4 keys:

- `expand`
- `expand_plural`
- `collapse`
- `legacyHint`

All nine secondary locales now have complete explicit coverage.

| Locale | Explicit | Missing | Extra | Placeholder mismatches |
| --- | ---: | ---: | ---: | ---: |
| EN | 4 | 0 | 0 | 0 |
| FR | 4 | 0 | 0 | 0 |
| DE | 4 | 0 | 0 | 0 |
| ES | 4 | 0 | 0 | 0 |
| PT-BR | 4 | 0 | 0 | 0 |
| IT | 4 | 0 | 0 | 0 |
| JA | 4 | 0 | 0 | 0 |
| PL | 4 | 0 | 0 | 0 |
| NL | 4 | 0 | 0 | 0 |
| RU | 4 | 0 | 0 | 0 |

## Placeholder validation

Placeholder parity is preserved exactly:

- `expand` → `{count}`
- `expand_plural` → `{count}`
- `collapse` → no placeholders
- `legacyHint` → `{count}`

## Scope

Catalog-only change.

No changes to:

- `InAppNotificationsBell.tsx`
- notification grouping or repeat behavior
- scanner notifications
- notification stacking
- notification destinations
- notification settings/templates
- English catalog
- any unrelated localization namespace

## Validation

- Runtime catalog evaluation passed
- Locale infrastructure tests: 2/2 passed
- Temporary esbuild bundle validation passed
- `git diff --check` passed
- No conflict markers
- No malformed Unicode/mojibake introduced
- Exactly 36 translated values added across 9 locale catalogs

## Diff

9 files changed, 9 insertions.